### PR TITLE
Hotfix: Fix bug for SystemRulesUpdater and FlowRulesUpdater

### DIFF
--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -24,7 +24,7 @@ func FlowRulesJsonConverter(src []byte) (interface{}, error) {
 // FlowRulesUpdater load the newest []flow.FlowRule to downstream flow component.
 func FlowRulesUpdater(data interface{}) error {
 	if data == nil {
-		return nil
+		return flow.ClearRules()
 	}
 
 	rules := make([]*flow.FlowRule, 0)
@@ -64,7 +64,7 @@ func SystemRulesJsonConverter(src []byte) (interface{}, error) {
 // SystemRulesUpdater load the newest []system.SystemRule to downstream system component.
 func SystemRulesUpdater(data interface{}) error {
 	if data == nil {
-		return nil
+		return system.ClearRules()
 	}
 
 	rules := make([]*system.SystemRule, 0)

--- a/ext/datasource/helper_test.go
+++ b/ext/datasource/helper_test.go
@@ -81,6 +81,22 @@ func TestFlowRulesJsonConverter(t *testing.T) {
 func TestFlowRulesUpdater(t *testing.T) {
 	t.Run("TestFlowRulesUpdater_Nil", func(t *testing.T) {
 		flow.ClearRules()
+		flow.LoadRules([]*flow.FlowRule{
+			{
+				ID:                0,
+				Resource:          "abc",
+				LimitOrigin:       "default",
+				MetricType:        0,
+				Count:             0,
+				RelationStrategy:  0,
+				ControlBehavior:   0,
+				RefResource:       "",
+				WarmUpPeriodSec:   0,
+				MaxQueueingTimeMs: 0,
+				ClusterMode:       false,
+				ClusterConfig:     flow.ClusterRuleConfig{},
+			}})
+		assert.True(t, len(flow.GetRules()) == 1, "Fail to prepare test data.")
 		err := FlowRulesUpdater(nil)
 		assert.True(t, err == nil && len(flow.GetRules()) == 0, "Fail to test TestFlowRulesUpdater_Nil")
 	})
@@ -189,6 +205,15 @@ func TestSystemRulesJsonConvert(t *testing.T) {
 func TestSystemRulesUpdater(t *testing.T) {
 	t.Run("TestSystemRulesUpdater_Nil", func(t *testing.T) {
 		system.ClearRules()
+		system.LoadRules([]*system.SystemRule{
+			&system.SystemRule{
+				ID:           0,
+				MetricType:   0,
+				TriggerCount: 0,
+				Strategy:     0,
+			},
+		})
+		assert.True(t, len(system.GetRules()) == 1, "Fail to prepare data.")
 		err := SystemRulesUpdater(nil)
 		assert.True(t, err == nil && len(system.GetRules()) == 0, "Fail to test TestSystemRulesUpdater_Nil")
 	})


### PR DESCRIPTION
### Describe what this PR does / why we need it
Hotfix: If the update value is nil in PropertyUpdater, sentinel should clear downstream property.

### Does this pull request fix one issue?

### Describe how you did it

### Describe how to verify it

### Special notes for reviews
