### PR TITLE
Etcdv3 datasource

### DIFF
--- a/ext/datasource/datasource.go
+++ b/ext/datasource/datasource.go
@@ -1,6 +1,8 @@
 package datasource
 
 import (
+	"fmt"
+	"go.uber.org/multierr"
 	"io"
 )
 
@@ -27,8 +29,17 @@ type Base struct {
 	handlers []PropertyHandler
 }
 
-func (b *Base) Handlers() []PropertyHandler {
-	return b.handlers
+func (b *Base) Handle(src []byte) (err error) {
+	for _, h := range b.handlers {
+		e := h.Handle(src)
+		if e != nil {
+			err = multierr.Append(err, e)
+		}
+	}
+	if err == nil {
+		return nil
+	}
+	return DSError{code: HandleSourceError, desc: fmt.Sprintf("%+v", err)}
 }
 
 // return idx if existed, else return -1

--- a/ext/datasource/datasource.go
+++ b/ext/datasource/datasource.go
@@ -39,7 +39,7 @@ func (b *Base) Handle(src []byte) (err error) {
 	if err == nil {
 		return nil
 	}
-	return DSError{code: HandleSourceError, desc: fmt.Sprintf("%+v", err)}
+	return Error{code: HandleSourceError, desc: fmt.Sprintf("%+v", err)}
 }
 
 // return idx if existed, else return -1

--- a/ext/datasource/error.go
+++ b/ext/datasource/error.go
@@ -1,0 +1,33 @@
+package datasource
+
+type Code uint32
+
+const (
+	OK                  = iota
+	ConvertSourceError  = 1
+	UpdatePropertyError = 2
+	HandleSourceError   = 3
+
+	EtcdKeyNotExistedError = 4
+	EtcdGetValueError      = 5
+)
+
+func NewDSError(code Code, desc string) DSError {
+	return DSError{
+		code: code,
+		desc: desc,
+	}
+}
+
+type DSError struct {
+	code Code
+	desc string
+}
+
+func (e DSError) Code() Code {
+	return e.code
+}
+
+func (e DSError) Error() string {
+	return e.desc
+}

--- a/ext/datasource/error.go
+++ b/ext/datasource/error.go
@@ -7,27 +7,24 @@ const (
 	ConvertSourceError  = 1
 	UpdatePropertyError = 2
 	HandleSourceError   = 3
-
-	EtcdKeyNotExistedError = 4
-	EtcdGetValueError      = 5
 )
 
-func NewDSError(code Code, desc string) DSError {
-	return DSError{
+func NewError(code Code, desc string) Error {
+	return Error{
 		code: code,
 		desc: desc,
 	}
 }
 
-type DSError struct {
+type Error struct {
 	code Code
 	desc string
 }
 
-func (e DSError) Code() Code {
+func (e Error) Code() Code {
 	return e.code
 }
 
-func (e DSError) Error() string {
+func (e Error) Error() string {
 	return e.desc
 }

--- a/ext/datasource/etcdv3/etcdv3.go
+++ b/ext/datasource/etcdv3/etcdv3.go
@@ -2,7 +2,6 @@ package etcdv3
 
 import (
 	"context"
-	"fmt"
 	"github.com/alibaba/sentinel-golang/ext/datasource"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
@@ -57,10 +56,10 @@ func (s *Etcdv3DataSource) ReadSource() ([]byte, error) {
 	defer cancel()
 	resp, err := s.client.Get(ctx, s.propertyKey)
 	if err != nil {
-		return nil, datasource.NewDSError(datasource.EtcdGetValueError, fmt.Sprintf("%+v", err))
+		return nil, errors.Errorf("Fail to get value for property key[%s]", s.propertyKey)
 	}
 	if resp.Count == 0 {
-		return nil, datasource.NewDSError(datasource.EtcdKeyNotExistedError, fmt.Sprintf("The key[%s] is not existed in etcd server.", s.propertyKey))
+		return nil, errors.Errorf("The key[%s] is not existed in etcd server.", s.propertyKey)
 	}
 	s.lastUpdatedRevision = resp.Header.GetRevision()
 	logger.Infof("Get the newest data for key:%s, revision: %d, value: %s", s.propertyKey, resp.Header.GetRevision(), resp.Kvs[0].Value)

--- a/ext/datasource/etcdv3/etcdv3.go
+++ b/ext/datasource/etcdv3/etcdv3.go
@@ -1,0 +1,137 @@
+package etcdv3
+
+import (
+	"context"
+	"fmt"
+	"github.com/alibaba/sentinel-golang/ext/datasource"
+	"github.com/alibaba/sentinel-golang/logging"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/pkg/errors"
+	"time"
+)
+
+var (
+	logger = logging.GetDefaultLogger()
+)
+
+type Etcdv3DataSource struct {
+	datasource.Base
+	propertyKey         string
+	lastUpdatedRevision int64
+	client              *clientv3.Client
+	// cancel is the func, call cancel will stop watching on the propertyKey
+	cancel context.CancelFunc
+	// closed indicate whether continuing to watch on the propertyKey
+	closed util.AtomicBool
+}
+
+// NewDatasource new a Etcdv3DataSource instance.
+// client is the etcdv3 client, it must be useful and should be release by User.
+func NewDatasource(client *clientv3.Client, key string, handlers ...datasource.PropertyHandler) (*Etcdv3DataSource, error) {
+	if client == nil {
+		return nil, errors.New("The etcdv3 client is nil.")
+	}
+	ds := &Etcdv3DataSource{
+		client:      client,
+		propertyKey: key,
+	}
+	for _, h := range handlers {
+		ds.AddPropertyHandler(h)
+	}
+	return ds, nil
+}
+
+func (s *Etcdv3DataSource) Initialize() error {
+	err := s.doReadAndUpdate()
+	if err != nil {
+		logger.Errorf("Fail to update data for key[%s] when execute Initialize function, err: %+v", s.propertyKey, err)
+	}
+	go util.RunWithRecover(s.watch, logger)
+	return nil
+}
+
+func (s *Etcdv3DataSource) ReadSource() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resp, err := s.client.Get(ctx, s.propertyKey)
+	if err != nil {
+		return nil, datasource.NewDSError(datasource.EtcdGetValueError, fmt.Sprintf("%+v", err))
+	}
+	if resp.Count == 0 {
+		return nil, datasource.NewDSError(datasource.EtcdKeyNotExistedError, fmt.Sprintf("The key[%s] is not existed in etcd server.", s.propertyKey))
+	}
+	s.lastUpdatedRevision = resp.Header.GetRevision()
+	logger.Infof("Get the newest data for key:%s, revision: %d, value: %s", s.propertyKey, resp.Header.GetRevision(), resp.Kvs[0].Value)
+	return resp.Kvs[0].Value, nil
+}
+
+func (s *Etcdv3DataSource) doReadAndUpdate() error {
+	src, err := s.ReadSource()
+	if err != nil {
+		return err
+	}
+	return s.Handle(src)
+}
+
+func (s *Etcdv3DataSource) processWatchResponse(resp *clientv3.WatchResponse) {
+	if resp.CompactRevision > s.lastUpdatedRevision {
+		s.lastUpdatedRevision = resp.CompactRevision
+	}
+	if resp.Header.GetRevision() > s.lastUpdatedRevision {
+		s.lastUpdatedRevision = resp.Header.GetRevision()
+	}
+
+	if err := resp.Err(); err != nil {
+		logger.Errorf("Watch on etcd endpoints(%+v) occur error, err: %+v", s.client.Endpoints(), err)
+		return
+	}
+
+	for _, ev := range resp.Events {
+		if ev.Type == mvccpb.PUT {
+			err := s.doReadAndUpdate()
+			if err != nil {
+				logger.Errorf("Fail to execute doReadAndUpdate for PUT event, err: %+v", err)
+			}
+		}
+		if ev.Type == mvccpb.DELETE {
+			updateErr := s.Handle(nil)
+			if updateErr != nil {
+				logger.Errorf("Fail to execute doReadAndUpdate for DELETE event, err: %+v", updateErr)
+			}
+		}
+	}
+}
+
+func (s *Etcdv3DataSource) watch() {
+	// Add watch for propertyKey from lastUpdatedRevision updated after Initializing
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	rch := s.client.Watch(ctx, s.propertyKey, clientv3.WithCreatedNotify(), clientv3.WithRev(s.lastUpdatedRevision))
+	for {
+		for resp := range rch {
+			s.processWatchResponse(&resp)
+		}
+		// Stop watching if datasource had been closed.
+		if s.closed.Get() {
+			return
+		}
+		time.Sleep(time.Duration(1) * time.Second)
+		ctx, cancel = context.WithCancel(context.Background())
+		s.cancel = cancel
+		if s.lastUpdatedRevision > 0 {
+			rch = s.client.Watch(ctx, s.propertyKey, clientv3.WithCreatedNotify(), clientv3.WithRev(s.lastUpdatedRevision))
+		} else {
+			rch = s.client.Watch(ctx, s.propertyKey, clientv3.WithCreatedNotify())
+		}
+	}
+}
+
+func (s *Etcdv3DataSource) Close() error {
+	// stop to watch property key.
+	s.closed.Set(true)
+	s.cancel()
+
+	return nil
+}

--- a/ext/datasource/etcdv3/etcdv3_example.go
+++ b/ext/datasource/etcdv3/etcdv3_example.go
@@ -1,0 +1,84 @@
+package etcdv3
+
+import (
+	"fmt"
+	"github.com/alibaba/sentinel-golang/ext/datasource"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/stretchr/testify/mock"
+	"log"
+	"time"
+)
+
+// New one datasource based on etcv3 client
+func Example_ClientWithOneDatasource() {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"localhost:2379"},
+		DialTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	defer cli.Close()
+
+	h := datasource.MockPropertyHandler{}
+	h.On("isPropertyConsistent", mock.Anything).Return(true)
+	h.On("Handle", mock.Anything).Return(nil)
+	ds, err := NewDatasource(cli, "foo", &h)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = ds.Initialize()
+	if err != nil {
+		log.Fatal(err)
+	}
+	time.Sleep(30 * time.Second)
+	fmt.Println("Prepare to close")
+	ds.Close()
+	time.Sleep(120 * time.Second)
+}
+
+// New multi datasource based on etcv3 client
+func Example_ClientWithMultiDatasource() {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"localhost:2379"},
+		DialTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		log.Fatal("client error:", err)
+	}
+	defer cli.Close()
+
+	h := datasource.MockPropertyHandler{}
+	h.On("isPropertyConsistent", mock.Anything).Return(true)
+	h.On("Handle", mock.Anything).Return(nil)
+	ds1, err := NewDatasource(cli, "foo", &h)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ds2, err := NewDatasource(cli, "aoo", &h)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = ds1.Initialize()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = ds2.Initialize()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(60 * time.Second)
+	fmt.Println("Prepare to close ds1")
+	// close ds1, will not recv the watch response
+	ds1.Close()
+
+	// ds2 also could recv the watch response
+	time.Sleep(80 * time.Second)
+	ds2.Close()
+
+	time.Sleep(100 * time.Second)
+}

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/alibaba/sentinel-golang/core/flow"
 	"github.com/alibaba/sentinel-golang/core/system"
-	"github.com/pkg/errors"
 )
 
 // FlowRulesJsonConverter provide JSON  as the default serialization for list of flow.FlowRule
@@ -16,7 +15,10 @@ func FlowRulesJsonConverter(src []byte) (interface{}, error) {
 	ret := make([]*flow.FlowRule, 0)
 	err := json.Unmarshal(src, &ret)
 	if err != nil {
-		return nil, errors.Errorf("Fail to unmarshal source: %+v to []flow.FlowRule, err: %+v", src, err)
+		return nil, DSError{
+			code: ConvertSourceError,
+			desc: fmt.Sprintf("Fail to unmarshal source: %s to []flow.FlowRule, err: %+v", src, err),
+		}
 	}
 	return ret, nil
 }
@@ -35,13 +37,19 @@ func FlowRulesUpdater(data interface{}) error {
 	} else if val, ok := data.([]*flow.FlowRule); ok {
 		rules = val
 	} else {
-		return errors.New(fmt.Sprintf("Fail to type assert data to []flow.FlowRule or []*flow.FlowRule, in fact, data: %+v", data))
+		return DSError{
+			code: UpdatePropertyError,
+			desc: fmt.Sprintf("Fail to type assert data to []flow.FlowRule or []*flow.FlowRule, in fact, data: %+v", data),
+		}
 	}
 	succ, err := flow.LoadRules(rules)
-	if succ {
-		return err
+	if succ && err == nil {
+		return nil
 	}
-	return err
+	return DSError{
+		code: UpdatePropertyError,
+		desc: fmt.Sprintf("%+v", err),
+	}
 }
 
 func NewFlowRulesHandler(converter PropertyConverter) PropertyHandler {
@@ -56,7 +64,10 @@ func SystemRulesJsonConverter(src []byte) (interface{}, error) {
 	ret := make([]*system.SystemRule, 0)
 	err := json.Unmarshal(src, &ret)
 	if err != nil {
-		return nil, errors.Errorf("Fail to unmarshal source: %+v to []system.SystemRule, err: %+v", src, err)
+		return nil, DSError{
+			code: ConvertSourceError,
+			desc: fmt.Sprintf("Fail to unmarshal source: %s to []system.SystemRule, err: %+v", src, err),
+		}
 	}
 	return ret, nil
 }
@@ -75,13 +86,19 @@ func SystemRulesUpdater(data interface{}) error {
 	} else if val, ok := data.([]*system.SystemRule); ok {
 		rules = val
 	} else {
-		return errors.New(fmt.Sprintf("Fail to type assert data to []system.SystemRule or []*system.SystemRule, in fact, data: %+v", data))
+		return DSError{
+			code: UpdatePropertyError,
+			desc: fmt.Sprintf("Fail to type assert data to []system.SystemRule or []*system.SystemRule, in fact, data: %+v", data),
+		}
 	}
 	succ, err := system.LoadRules(rules)
-	if succ {
-		return err
+	if succ && err == nil {
+		return nil
 	}
-	return err
+	return DSError{
+		code: UpdatePropertyError,
+		desc: fmt.Sprintf("%+v", err),
+	}
 }
 
 func NewSystemRulesHandler(converter PropertyConverter) *DefaultPropertyHandler {

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -15,7 +15,7 @@ func FlowRulesJsonConverter(src []byte) (interface{}, error) {
 	ret := make([]*flow.FlowRule, 0)
 	err := json.Unmarshal(src, &ret)
 	if err != nil {
-		return nil, DSError{
+		return nil, Error{
 			code: ConvertSourceError,
 			desc: fmt.Sprintf("Fail to unmarshal source: %s to []flow.FlowRule, err: %+v", src, err),
 		}
@@ -37,7 +37,7 @@ func FlowRulesUpdater(data interface{}) error {
 	} else if val, ok := data.([]*flow.FlowRule); ok {
 		rules = val
 	} else {
-		return DSError{
+		return Error{
 			code: UpdatePropertyError,
 			desc: fmt.Sprintf("Fail to type assert data to []flow.FlowRule or []*flow.FlowRule, in fact, data: %+v", data),
 		}
@@ -46,7 +46,7 @@ func FlowRulesUpdater(data interface{}) error {
 	if succ && err == nil {
 		return nil
 	}
-	return DSError{
+	return Error{
 		code: UpdatePropertyError,
 		desc: fmt.Sprintf("%+v", err),
 	}
@@ -64,7 +64,7 @@ func SystemRulesJsonConverter(src []byte) (interface{}, error) {
 	ret := make([]*system.SystemRule, 0)
 	err := json.Unmarshal(src, &ret)
 	if err != nil {
-		return nil, DSError{
+		return nil, Error{
 			code: ConvertSourceError,
 			desc: fmt.Sprintf("Fail to unmarshal source: %s to []system.SystemRule, err: %+v", src, err),
 		}
@@ -86,7 +86,7 @@ func SystemRulesUpdater(data interface{}) error {
 	} else if val, ok := data.([]*system.SystemRule); ok {
 		rules = val
 	} else {
-		return DSError{
+		return Error{
 			code: UpdatePropertyError,
 			desc: fmt.Sprintf("Fail to type assert data to []system.SystemRule or []*system.SystemRule, in fact, data: %+v", data),
 		}
@@ -95,7 +95,7 @@ func SystemRulesUpdater(data interface{}) error {
 	if succ && err == nil {
 		return nil
 	}
-	return DSError{
+	return Error{
 		code: UpdatePropertyError,
 		desc: fmt.Sprintf("%+v", err),
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/apache/dubbo-go v0.1.2-0.20200224151332-dd1a3c24d656
+	github.com/coreos/etcd v3.3.13+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gin-gonic/gin v1.5.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coredns/coredns v1.1.2/go.mod h1:zASH/MVDgR6XZTbxvOnsZfffS+31vg6Ackf/wo1+AM0=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
+github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -104,6 +105,7 @@ github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/gocql/gocql v0.0.0-20180617115710-e06f8c1bcd78/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=


### PR DESCRIPTION
### Describe what this PR does / why we need it

extend etcdv3 as datasource.
1.  Introduce DatasourceGenerator to generate Etcdv3DataSource.
2. All Etcdv3DataSources generated by DatasourceGenerator instance will reuse the etcdv3 client long lived http connection.
3. Etcdv3DataSource could be closed,  if all Etcdv3DataSources generated by DatasourceGenerator instance were clsoed, DatasourceGenerator will be closed, which means etcdv3 client will be closed.
4. DatasourceGenerator only expose the function Generate.

### Does this pull request fix one issue?

### Describe how you did it

### Describe how to verify it

### Special notes for reviews