### PR TITLE
make EntryOptions support storing custom data before Sentinel.Entry()

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ type EntryOptions struct {
 	flag         int32
 	slotChain    *base.SlotChain
 	args         []interface{}
+	data         map[string]interface{}
 }
 
 type EntryOption func(*EntryOptions)
@@ -51,6 +52,22 @@ func WithArgs(args ...interface{}) EntryOption {
 	}
 }
 
+// WithData set the resource entry with the given k-v pair
+func WithData(key string, value interface{}) EntryOption {
+	return func(opts *EntryOptions) {
+		opts.data[key] = value
+	}
+}
+
+// WithDatas set the resource entry with the given k-v pairs
+func WithDatas(data map[string]interface{}) EntryOption {
+	return func(opts *EntryOptions) {
+		for key, value := range data {
+			opts.data[key] = value
+		}
+	}
+}
+
 // Entry is the basic API of Sentinel.
 func Entry(resource string, opts ...EntryOption) (*base.SentinelEntry, *base.BlockError) {
 	var options = EntryOptions{
@@ -60,6 +77,7 @@ func Entry(resource string, opts ...EntryOption) (*base.SentinelEntry, *base.Blo
 		flag:         0,
 		slotChain:    globalSlotChain,
 		args:         []interface{}{},
+		data:         make(map[string]interface{}),
 	}
 	for _, opt := range opts {
 		opt(&options)

--- a/api/api.go
+++ b/api/api.go
@@ -12,7 +12,7 @@ type EntryOptions struct {
 	flag         int32
 	slotChain    *base.SlotChain
 	args         []interface{}
-	data         map[string]interface{}
+	attachments  map[interface{}]interface{}
 }
 
 type EntryOption func(*EntryOptions)
@@ -52,18 +52,18 @@ func WithArgs(args ...interface{}) EntryOption {
 	}
 }
 
-// WithData set the resource entry with the given k-v pair
-func WithData(key string, value interface{}) EntryOption {
+// WithAttachment set the resource entry with the given k-v pair
+func WithAttachment(key interface{}, value interface{}) EntryOption {
 	return func(opts *EntryOptions) {
-		opts.data[key] = value
+		opts.attachments[key] = value
 	}
 }
 
-// WithDatas set the resource entry with the given k-v pairs
-func WithDatas(data map[string]interface{}) EntryOption {
+// WithAttachment set the resource entry with the given k-v pairs
+func WithAttachments(data map[interface{}]interface{}) EntryOption {
 	return func(opts *EntryOptions) {
 		for key, value := range data {
-			opts.data[key] = value
+			opts.attachments[key] = value
 		}
 	}
 }
@@ -77,7 +77,7 @@ func Entry(resource string, opts ...EntryOption) (*base.SentinelEntry, *base.Blo
 		flag:         0,
 		slotChain:    globalSlotChain,
 		args:         []interface{}{},
-		data:         make(map[string]interface{}),
+		attachments:  make(map[interface{}]interface{}),
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -100,6 +100,7 @@ func entry(resource string, options *EntryOptions) (*base.SentinelEntry, *base.B
 		AcquireCount: options.acquireCount,
 		Flag:         options.flag,
 		Args:         options.args,
+		Attachments:  options.attachments,
 	}
 
 	e := base.NewSentinelEntry(ctx, rw, sc)

--- a/core/base/context.go
+++ b/core/base/context.go
@@ -36,7 +36,7 @@ type SentinelInput struct {
 	Args         []interface{}
 
 	// store some values in this context when calling context in slot.
-	data map[interface{}]interface{}
+	Attachments map[interface{}]interface{}
 }
 
 func newEmptyInput() *SentinelInput {
@@ -47,7 +47,7 @@ type SentinelOutput struct {
 	LastResult *TokenResult
 
 	// store output data.
-	data map[interface{}]interface{}
+	Attachments map[interface{}]interface{}
 }
 
 func newEmptyOutput() *SentinelOutput {

--- a/core/base/slot_chain_test.go
+++ b/core/base/slot_chain_test.go
@@ -224,7 +224,7 @@ func TestSlotChain_Entry_Pass_And_Exit(t *testing.T) {
 		AcquireCount: 1,
 		Flag:         0,
 		Args:         nil,
-		data:         nil,
+		Attachments:  nil,
 	}
 
 	ps1 := &prepareSlotMock{}
@@ -266,7 +266,7 @@ func TestSlotChain_Entry_Block(t *testing.T) {
 		AcquireCount: 1,
 		Flag:         0,
 		Args:         nil,
-		data:         nil,
+		Attachments:  nil,
 	}
 
 	rbs := &prepareSlotMock{}
@@ -324,7 +324,7 @@ func TestSlotChain_Entry_With_Panic(t *testing.T) {
 		AcquireCount: 1,
 		Flag:         0,
 		Args:         nil,
-		data:         nil,
+		Attachments:  nil,
 	}
 
 	rbs := &badPrepareSlotMock{}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

We need to pass some data about current invocation to slots, while these data is parsed before `Sentinel.Entry()`. `EntryOptions` is a suitable place but extra attribute is required.

### Does this pull request fix one issue?

None.

### Describe how you did it

Add a map `data map[string]interface{}` (and several functions associated) to `EntryOptions`.

### Describe how to verify it


### Special notes for reviews