### PR TITLE
Organize imports in groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 
 script:
   - diff -u <(echo -n) <(gofmt -d -s .)
+  - diff -u <(echo -n) <(goimports -d .)
   - go test -v -race ./... -coverprofile=coverage.txt -covermode=atomic
 
 after_success:

--- a/adapter/echo/middleware_test.go
+++ b/adapter/echo/middleware_test.go
@@ -1,7 +1,6 @@
 package echo
 
 import (
-	"github.com/labstack/echo/v4"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +8,7 @@ import (
 
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/flow"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/adapter/grpc/server_test.go
+++ b/adapter/grpc/server_test.go
@@ -3,12 +3,12 @@ package grpc
 import (
 	"context"
 	"errors"
-	"github.com/alibaba/sentinel-golang/core/stat"
 	"testing"
 
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/flow"
+	"github.com/alibaba/sentinel-golang/core/stat"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"testing"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 type prepareSlotMock struct {

--- a/api/init.go
+++ b/api/init.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/alibaba/sentinel-golang/core/config"
 	"github.com/alibaba/sentinel-golang/core/log/metric"
 	"github.com/alibaba/sentinel-golang/core/system"

--- a/core/base/context_test.go
+++ b/core/base/context_test.go
@@ -1,8 +1,9 @@
 package base
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEntryContext_IsBlocked(t *testing.T) {

--- a/core/base/metric_item_test.go
+++ b/core/base/metric_item_test.go
@@ -1,8 +1,9 @@
 package base
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMetricItemFromFatStringLegal(t *testing.T) {

--- a/core/base/slot_chain.go
+++ b/core/base/slot_chain.go
@@ -1,9 +1,10 @@
 package base
 
 import (
+	"sync"
+
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
-	"sync"
 )
 
 var logger = logging.GetDefaultLogger()

--- a/core/base/slot_chain_test.go
+++ b/core/base/slot_chain_test.go
@@ -2,12 +2,13 @@ package base
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type StatPrepareSlotMock1 struct {

--- a/core/circuit_breaker/circuit_breaker.go
+++ b/core/circuit_breaker/circuit_breaker.go
@@ -1,11 +1,12 @@
 package circuit_breaker
 
 import (
+	"sync/atomic"
+	"time"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/stat"
 	"github.com/alibaba/sentinel-golang/util"
-	"sync/atomic"
-	"time"
 )
 
 type CircuitBreaker interface {

--- a/core/circuit_breaker/rule.go
+++ b/core/circuit_breaker/rule.go
@@ -3,6 +3,7 @@ package circuit_breaker
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/util"
 	"github.com/pkg/errors"

--- a/core/circuit_breaker/rule_manager.go
+++ b/core/circuit_breaker/rule_manager.go
@@ -2,9 +2,10 @@ package circuit_breaker
 
 import (
 	"fmt"
-	"github.com/alibaba/sentinel-golang/logging"
 	"strings"
 	"sync"
+
+	"github.com/alibaba/sentinel-golang/logging"
 )
 
 var (

--- a/core/circuit_breaker/rule_manager_test.go
+++ b/core/circuit_breaker/rule_manager_test.go
@@ -1,9 +1,10 @@
 package circuit_breaker
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_isApplicableRule(t *testing.T) {

--- a/core/circuit_breaker/slot.go
+++ b/core/circuit_breaker/slot.go
@@ -1,8 +1,9 @@
 package circuit_breaker
 
 import (
-	"github.com/alibaba/sentinel-golang/core/base"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/core/base"
 )
 
 type CircuitBreakerSlot struct {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -2,15 +2,16 @@ package config
 
 import (
 	"fmt"
-	"github.com/alibaba/sentinel-golang/logging"
-	"github.com/alibaba/sentinel-golang/util"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"sync"
+
+	"github.com/alibaba/sentinel-golang/logging"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -1,9 +1,9 @@
 package flow
 
 import (
-	"github.com/stretchr/testify/assert"
-
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetAndRemoveTrafficShapingGenerator(t *testing.T) {

--- a/core/flow/slot.go
+++ b/core/flow/slot.go
@@ -1,9 +1,10 @@
 package flow
 
 import (
+	"time"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/stat"
-	"time"
 )
 
 // FlowSlot

--- a/core/flow/tc_throttling.go
+++ b/core/flow/tc_throttling.go
@@ -1,11 +1,12 @@
 package flow
 
 import (
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/util"
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/util"
 )
 
 const nanoUnitOffset = time.Second / time.Nanosecond

--- a/core/flow/tc_throttling_test.go
+++ b/core/flow/tc_throttling_test.go
@@ -1,12 +1,13 @@
 package flow
 
 import (
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestThrottlingChecker_DoCheckNoQueueingSingleThread(t *testing.T) {

--- a/core/log/metric/aggregator.go
+++ b/core/log/metric/aggregator.go
@@ -1,14 +1,15 @@
 package metric
 
 import (
+	"sort"
+	"sync"
+	"time"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/config"
 	"github.com/alibaba/sentinel-golang/core/stat"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
-	"sort"
-	"sync"
-	"time"
 )
 
 type metricTimeMap = map[uint64][]*base.MetricItem

--- a/core/log/metric/aggregator_test.go
+++ b/core/log/metric/aggregator_test.go
@@ -1,11 +1,12 @@
 package metric
 
 import (
+	"testing"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/stat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 const (

--- a/core/log/metric/common.go
+++ b/core/log/metric/common.go
@@ -1,7 +1,6 @@
 package metric
 
 import (
-	"github.com/alibaba/sentinel-golang/core/base"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -9,6 +8,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/alibaba/sentinel-golang/core/base"
 )
 
 const (

--- a/core/log/metric/reader.go
+++ b/core/log/metric/reader.go
@@ -2,10 +2,11 @@ package metric
 
 import (
 	"bufio"
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/pkg/errors"
 	"io"
 	"os"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/pkg/errors"
 )
 
 const maxItemAmount = 100000

--- a/core/log/metric/searcher.go
+++ b/core/log/metric/searcher.go
@@ -2,12 +2,13 @@ package metric
 
 import (
 	"encoding/binary"
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/util"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"sync"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/pkg/errors"
 )
 
 const offsetNotFound = -1

--- a/core/log/metric/writer.go
+++ b/core/log/metric/writer.go
@@ -4,15 +4,16 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/core/config"
-	"github.com/alibaba/sentinel-golang/util"
-	"github.com/pkg/errors"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/core/config"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/pkg/errors"
 )
 
 type DefaultMetricLogWriter struct {

--- a/core/stat/base/atomic_window_wrap_array_test.go
+++ b/core/stat/base/atomic_window_wrap_array_test.go
@@ -1,13 +1,14 @@
 package base
 
 import (
-	"github.com/alibaba/sentinel-golang/util"
 	"math/rand"
 	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/util"
 )
 
 func Test_newAtomicBucketWrapArray_normal(t *testing.T) {

--- a/core/stat/base/bucket_leap_array.go
+++ b/core/stat/base/bucket_leap_array.go
@@ -2,11 +2,12 @@ package base
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
 	"github.com/pkg/errors"
-	"sync/atomic"
 )
 
 var logger = logging.GetDefaultLogger()

--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -2,12 +2,13 @@ package base
 
 import (
 	"fmt"
-	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/util"
-	"github.com/pkg/errors"
 	"runtime"
 	"sync/atomic"
 	"unsafe"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/core/stat/base/metric_bucket.go
+++ b/core/stat/base/metric_bucket.go
@@ -2,8 +2,9 @@ package base
 
 import (
 	"fmt"
-	"github.com/alibaba/sentinel-golang/core/base"
 	"sync/atomic"
+
+	"github.com/alibaba/sentinel-golang/core/base"
 )
 
 // MetricBucket represents the entity to record metrics per minimum time unit (i.e. the bucket time span).

--- a/core/stat/base/metric_bucket_test.go
+++ b/core/stat/base/metric_bucket_test.go
@@ -1,10 +1,11 @@
 package base
 
 import (
-	"github.com/alibaba/sentinel-golang/core/base"
 	"sync"
 	"testing"
 	"unsafe"
+
+	"github.com/alibaba/sentinel-golang/core/base"
 )
 
 func Test_metricBucket_MemSize(t *testing.T) {

--- a/core/stat/base/sliding_window_metric.go
+++ b/core/stat/base/sliding_window_metric.go
@@ -2,9 +2,10 @@ package base
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/util"
-	"sync/atomic"
 )
 
 // SlidingWindowMetric represents the sliding window metric wrapper.

--- a/core/stat/base_node.go
+++ b/core/stat/base_node.go
@@ -1,9 +1,10 @@
 package stat
 
 import (
+	"sync/atomic"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	sbase "github.com/alibaba/sentinel-golang/core/stat/base"
-	"sync/atomic"
 )
 
 type BaseStatNode struct {

--- a/core/stat/node_storage.go
+++ b/core/stat/node_storage.go
@@ -1,9 +1,10 @@
 package stat
 
 import (
+	"sync"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/logging"
-	"sync"
 )
 
 type ResourceNodeMap map[string]*ResourceNode

--- a/core/stat/resource_node.go
+++ b/core/stat/resource_node.go
@@ -2,9 +2,10 @@ package stat
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	sbase "github.com/alibaba/sentinel-golang/core/stat/base"
-	"sync"
 )
 
 type ResourceNode struct {

--- a/core/stat/resource_node_test.go
+++ b/core/stat/resource_node_test.go
@@ -2,11 +2,11 @@ package stat
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 
 	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResourceNode_GetOrCreateSlidingWindowMetric(t *testing.T) {

--- a/core/system/rule_manager.go
+++ b/core/system/rule_manager.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/alibaba/sentinel-golang/logging"
-
 	"github.com/pkg/errors"
 )
 

--- a/core/system/slot_test.go
+++ b/core/system/slot_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/stat"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/system/sys_stat.go
+++ b/core/system/sys_stat.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alibaba/sentinel-golang/util"
-
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/load"
 )

--- a/example/qps_limit_example.go
+++ b/example/qps_limit_example.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/flow"
 	"github.com/alibaba/sentinel-golang/util"
-	"log"
-	"math/rand"
-	"time"
 )
 
 func main() {

--- a/ext/datasource/datasource.go
+++ b/ext/datasource/datasource.go
@@ -2,8 +2,9 @@ package datasource
 
 import (
 	"fmt"
-	"go.uber.org/multierr"
 	"io"
+
+	"go.uber.org/multierr"
 )
 
 // The generic interface to describe the datasource

--- a/ext/datasource/datasource_test.go
+++ b/ext/datasource/datasource_test.go
@@ -1,9 +1,10 @@
 package datasource
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBase_AddPropertyHandler(t *testing.T) {

--- a/ext/datasource/etcdv3/etcdv3.go
+++ b/ext/datasource/etcdv3/etcdv3.go
@@ -2,13 +2,14 @@ package etcdv3
 
 import (
 	"context"
+	"time"
+
 	"github.com/alibaba/sentinel-golang/ext/datasource"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/pkg/errors"
-	"time"
 )
 
 var (

--- a/ext/datasource/etcdv3/etcdv3_example.go
+++ b/ext/datasource/etcdv3/etcdv3_example.go
@@ -2,11 +2,12 @@ package etcdv3
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/alibaba/sentinel-golang/ext/datasource"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/stretchr/testify/mock"
-	"log"
-	"time"
 )
 
 // New one datasource based on etcv3 client

--- a/ext/datasource/file/refreshable_file.go
+++ b/ext/datasource/file/refreshable_file.go
@@ -1,13 +1,14 @@
 package file
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/alibaba/sentinel-golang/ext/datasource"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"os"
 )
 
 var (

--- a/ext/datasource/file/refreshable_file_test.go
+++ b/ext/datasource/file/refreshable_file_test.go
@@ -1,16 +1,17 @@
 package file
 
 import (
-	"github.com/alibaba/sentinel-golang/ext/datasource"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	tmock "github.com/stretchr/testify/mock"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/alibaba/sentinel-golang/ext/datasource"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	tmock "github.com/stretchr/testify/mock"
 )
 
 const (

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/alibaba/sentinel-golang/core/flow"
 	"github.com/alibaba/sentinel-golang/core/system"
 )

--- a/ext/datasource/helper_test.go
+++ b/ext/datasource/helper_test.go
@@ -2,15 +2,16 @@ package datasource
 
 import (
 	"encoding/json"
-	"github.com/alibaba/sentinel-golang/core/flow"
-	"github.com/alibaba/sentinel-golang/core/system"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/alibaba/sentinel-golang/core/flow"
+	"github.com/alibaba/sentinel-golang/core/system"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFlowRulesJsonConverter(t *testing.T) {

--- a/ext/datasource/property.go
+++ b/ext/datasource/property.go
@@ -1,9 +1,10 @@
 package datasource
 
 import (
+	"reflect"
+
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/pkg/errors"
-	"reflect"
 )
 
 var logger = logging.GetDefaultLogger()

--- a/ext/datasource/property_test.go
+++ b/ext/datasource/property_test.go
@@ -2,11 +2,12 @@ package datasource
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"testing"
+
 	"github.com/alibaba/sentinel-golang/core/system"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 func MockSystemRulesConverter(src []byte) (interface{}, error) {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,12 +1,13 @@
 package logging
 
 import (
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSimpleFileLogger(t *testing.T) {

--- a/util/atomic_test.go
+++ b/util/atomic_test.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAtomicBool_CompareAndSet(t *testing.T) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/alibaba/sentinel-golang/logging"
 	"testing"
+
+	"github.com/alibaba/sentinel-golang/logging"
 )
 
 func TestWithRecoverGo(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: wuxu <wuxu1103@163.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Imports are organized in groups, with blank lines between them. The standard library packages are always in the first group.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #135 
### Describe how you did it


### Describe how to verify it


### Special notes for reviews