### PR TITLE
fix error message of test for bucket wrapper size

### DIFF
--- a/core/stat/base/leap_array_test.go
+++ b/core/stat/base/leap_array_test.go
@@ -20,25 +20,15 @@ const (
 )
 
 func Test_bucketWrapper_Size(t *testing.T) {
-	type Obj struct {
-		a1 int32 // 4bytes
-		a2 int32
-		a3 int32
-		a4 int32
-		a5 int32
-		a6 int32
-		a7 int32
-		a8 int32
-	}
 	ww := &BucketWrap{
 		BucketStart: util.CurrentTimeMillis(),
 		Value:       atomic.Value{},
 	}
 	if unsafe.Sizeof(*ww) != 24 {
-		t.Errorf("the size of BucketWrap is not equal 20.\n")
+		t.Errorf("the size of BucketWrap is not equal 24.\n")
 	}
 	if unsafe.Sizeof(ww) != 8 {
-		t.Errorf("the size of BucketWrap is not equal 20.\n")
+		t.Errorf("the size of BucketWrap is not equal 24.\n")
 	}
 }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

The size of BucketWrap is 24 bytes and the test for bucket wrapper size has wrong error message. 

### Does this pull request fix one issue?

NONE

### Special notes for reviews

NONE