### PR TITLE
Improve all rule checking slots with standard BlockError representation

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -103,7 +103,7 @@ func Test_entryWithArgsAndChainBlock(t *testing.T) {
 	blockType := base.BlockTypeFlow
 
 	ps1.On("Prepare", mock.Anything).Return()
-	rcs1.On("Check", mock.Anything).Return(base.NewTokenResultBlocked(blockType, "Flow"))
+	rcs1.On("Check", mock.Anything).Return(base.NewTokenResultBlocked(blockType))
 	rcs2.On("Check", mock.Anything).Return(base.NewTokenResultPass())
 	ssm.On("OnEntryPassed", mock.Anything).Return()
 	ssm.On("OnEntryBlocked", mock.Anything, mock.Anything).Return()

--- a/core/base/block_error.go
+++ b/core/base/block_error.go
@@ -5,9 +5,11 @@ import "fmt"
 // BlockError indicates the request was blocked by Sentinel.
 type BlockError struct {
 	blockType BlockType
-	blockMsg  string
+	// blockMsg provides additional message for the block error.
+	blockMsg string
 
-	rule          SentinelRule
+	rule SentinelRule
+	// snapshotValue represents the triggered "snapshot" value
 	snapshotValue interface{}
 }
 
@@ -36,8 +38,12 @@ func NewBlockErrorFromDeepCopy(from *BlockError) *BlockError {
 	}
 }
 
-func NewBlockError(blockType BlockType, blockMsg string) *BlockError {
-	return &BlockError{blockType: blockType, blockMsg: blockMsg}
+func NewBlockError(blockType BlockType) *BlockError {
+	return &BlockError{blockType: blockType}
+}
+
+func NewBlockErrorWithMessage(blockType BlockType, message string) *BlockError {
+	return &BlockError{blockType: blockType, blockMsg: message}
 }
 
 func NewBlockErrorWithCause(blockType BlockType, blockMsg string, rule SentinelRule, snapshot interface{}) *BlockError {
@@ -45,6 +51,8 @@ func NewBlockErrorWithCause(blockType BlockType, blockMsg string, rule SentinelR
 }
 
 func (e *BlockError) Error() string {
-	return fmt.Sprintf("Sentinel block error: blockType:%s, message: %s, rule: %+v, snapshotValue: %+v",
-		e.blockType, e.blockMsg, e.rule, e.snapshotValue)
+	if len(e.blockMsg) == 0 {
+		return fmt.Sprintf("SentinelBlockError: %s", e.blockType.String())
+	}
+	return fmt.Sprintf("SentinelBlockError: %s, message: %s", e.blockType.String(), e.blockMsg)
 }

--- a/core/base/context_test.go
+++ b/core/base/context_test.go
@@ -9,6 +9,6 @@ import (
 func TestEntryContext_IsBlocked(t *testing.T) {
 	ctx := NewEmptyEntryContext()
 	assert.False(t, ctx.IsBlocked(), "empty context with no result should indicate pass")
-	ctx.RuleCheckResult = NewTokenResultBlocked(BlockTypeUnknown, "Unknown")
+	ctx.RuleCheckResult = NewTokenResultBlocked(BlockTypeUnknown)
 	assert.True(t, ctx.IsBlocked(), "context with blocked request should indicate blocked")
 }

--- a/core/base/slot_chain_test.go
+++ b/core/base/slot_chain_test.go
@@ -283,7 +283,7 @@ func TestSlotChain_Entry_Block(t *testing.T) {
 
 	rbs.On("Prepare", mock.Anything).Return()
 	fsm.On("Check", mock.Anything).Return(NewTokenResultPass())
-	dsm.On("Check", mock.Anything).Return(NewTokenResultBlocked(blockType, "Unknown"))
+	dsm.On("Check", mock.Anything).Return(NewTokenResultBlocked(blockType))
 	ssm.On("OnEntryPassed", mock.Anything).Return()
 	ssm.On("OnEntryBlocked", mock.Anything, mock.Anything).Return()
 	ssm.On("OnCompleted", mock.Anything).Return()
@@ -339,7 +339,7 @@ func TestSlotChain_Entry_With_Panic(t *testing.T) {
 
 	rbs.On("Prepare", mock.Anything).Return()
 	fsm.On("Check", mock.Anything).Return(NewTokenResultPass())
-	dsm.On("Check", mock.Anything).Return(NewTokenResultBlocked(BlockTypeUnknown, "Unknown"))
+	dsm.On("Check", mock.Anything).Return(NewTokenResultBlocked(BlockTypeUnknown))
 	ssm.On("OnEntryPassed", mock.Anything).Return()
 	ssm.On("OnEntryBlocked", mock.Anything, mock.Anything).Return()
 	ssm.On("OnCompleted", mock.Anything).Return()

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -30,7 +30,7 @@ var (
 func init() {
 	// Initialize the traffic shaping controller generator map for existing control behaviors.
 	tcGenFuncMap[Reject] = func(rule *FlowRule) *TrafficShapingController {
-		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewDefaultTrafficShapingChecker(rule.MetricType), rule)
+		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewDefaultTrafficShapingChecker(rule), rule)
 	}
 	tcGenFuncMap[Throttling] = func(rule *FlowRule) *TrafficShapingController {
 		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewThrottlingChecker(rule.MaxQueueingTimeMs), rule)

--- a/core/flow/tc_default.go
+++ b/core/flow/tc_default.go
@@ -17,11 +17,11 @@ func (d *DefaultTrafficShapingCalculator) CalculateAllowedTokens(base.StatNode, 
 }
 
 type DefaultTrafficShapingChecker struct {
-	metricType MetricType
+	rule *FlowRule
 }
 
-func NewDefaultTrafficShapingChecker(metricType MetricType) *DefaultTrafficShapingChecker {
-	return &DefaultTrafficShapingChecker{metricType: metricType}
+func NewDefaultTrafficShapingChecker(rule *FlowRule) *DefaultTrafficShapingChecker {
+	return &DefaultTrafficShapingChecker{rule: rule}
 }
 
 func (d *DefaultTrafficShapingChecker) DoCheck(node base.StatNode, acquireCount uint32, threshold float64) *base.TokenResult {
@@ -29,13 +29,13 @@ func (d *DefaultTrafficShapingChecker) DoCheck(node base.StatNode, acquireCount 
 		return nil
 	}
 	var curCount float64
-	if d.metricType == Concurrency {
+	if d.rule.MetricType == Concurrency {
 		curCount = float64(node.CurrentGoroutineNum())
 	} else {
 		curCount = node.GetQPS(base.MetricEventPass)
 	}
 	if curCount+float64(acquireCount) > threshold {
-		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+		return base.NewTokenResultBlockedWithCause(base.BlockTypeFlow, "", d.rule, curCount)
 	}
 	return nil
 }

--- a/core/flow/tc_throttling.go
+++ b/core/flow/tc_throttling.go
@@ -34,7 +34,7 @@ func (c *ThrottlingChecker) DoCheck(_ base.StatNode, acquireCount uint32, thresh
 		return nil
 	}
 	if threshold <= 0 {
-		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+		return base.NewTokenResultBlocked(base.BlockTypeFlow)
 	}
 	// Here we use nanosecond so that we could control the queueing time more accurately.
 	curNano := util.CurrentTimeNano()
@@ -50,7 +50,7 @@ func (c *ThrottlingChecker) DoCheck(_ base.StatNode, acquireCount uint32, thresh
 	}
 	estimatedQueueingDuration := atomic.LoadUint64(&c.lastPassedTime) + interval - util.CurrentTimeNano()
 	if estimatedQueueingDuration > c.maxQueueingTimeNs {
-		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+		return base.NewTokenResultBlocked(base.BlockTypeFlow)
 	}
 
 	oldTime := atomic.AddUint64(&c.lastPassedTime, interval)
@@ -58,7 +58,7 @@ func (c *ThrottlingChecker) DoCheck(_ base.StatNode, acquireCount uint32, thresh
 	if estimatedQueueingDuration > c.maxQueueingTimeNs {
 		// Subtract the interval.
 		atomic.AddUint64(&c.lastPassedTime, ^(interval - 1))
-		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+		return base.NewTokenResultBlocked(base.BlockTypeFlow)
 	}
 	if estimatedQueueingDuration > 0 {
 		return base.NewTokenResultShouldWait(estimatedQueueingDuration / util.UnixTimeUnitOffset)

--- a/core/hotspot/traffic_shaping.go
+++ b/core/hotspot/traffic_shaping.go
@@ -87,16 +87,14 @@ func (c *baseTrafficShapingController) performCheckingForConcurrencyMetric(arg i
 			return nil
 		}
 		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-			fmt.Sprintf("Blocked by specific concurrency threshold, arg: %+v, current concurrency: %d,  specific concurrency: %d", arg, concurrency, specificConcurrency),
-			c.BoundRule(), concurrency)
+			fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 	}
 	threshold := int64(c.threshold)
 	if concurrency <= threshold {
 		return nil
 	}
 	return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-		fmt.Sprintf("Blocked by concurrency threshold, arg: %+v, current concurrency: %d, threshold concurrency: %d", arg, concurrency, threshold),
-		c.BoundRule(), concurrency)
+		fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 }
 
 // rejectTrafficShapingController use Reject strategy
@@ -145,14 +143,13 @@ func (c *rejectTrafficShapingController) PerformChecking(arg interface{}, acquir
 	}
 	if tokenCount <= 0 {
 		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-			fmt.Sprintf("Blocked by reject traffic shaping controller, arg: %+v", arg), c.BoundRule(), "")
+			fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 	}
 	maxCount := tokenCount + c.burstCount
 	if acquireCount > maxCount {
 		// return blocked because the acquired number is more than max count of rejectTrafficShapingController
 		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-			fmt.Sprintf("Blocked by reject traffic shaping controller, arg: %+v, the acquired number(%d) is more than max count(%d) of rejectTrafficShapingController", arg, acquireCount, maxCount),
-			c.BoundRule(), "")
+			fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 	}
 
 	for {
@@ -187,8 +184,7 @@ func (c *rejectTrafficShapingController) PerformChecking(arg interface{}, acquir
 				}
 				if newQps < 0 {
 					return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-						fmt.Sprintf("rejectTrafficShapingController, the new QPS after subbing acquire(%d) is less than 0.", acquireCount),
-						c.BoundRule(), "")
+						fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 				}
 				if atomic.CompareAndSwapInt64(oldQpsPtr, restQps, newQps) {
 					atomic.StoreInt64(lastAddTokenTimePtr, currentTimeInMs)
@@ -208,8 +204,7 @@ func (c *rejectTrafficShapingController) PerformChecking(arg interface{}, acquir
 					}
 				} else {
 					return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-						fmt.Sprintf("rejectTrafficShapingController, the rest token is not enough, oldRestToken: %d, acquire: %d", oldRestToken, acquireCount),
-						c.BoundRule(), "")
+						fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 				}
 			}
 			runtime.Gosched()
@@ -242,7 +237,8 @@ func (c *throttlingTrafficShapingController) PerformChecking(arg interface{}, ac
 		tokenCount = val
 	}
 	if tokenCount <= 0 {
-		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow, "throttlingTrafficShapingController, the setting tokenCount is <= 0", c.BoundRule(), "")
+		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
+			fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 	}
 	intervalCostTime := int64(math.Round(float64(acquireCount * c.durationInSec * 1000 / tokenCount)))
 	for {
@@ -270,8 +266,7 @@ func (c *throttlingTrafficShapingController) PerformChecking(arg interface{}, ac
 			}
 		} else {
 			return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-				fmt.Sprintf("throttlingTrafficShapingController, current time(%d) is not reaching to expected time(%d)", currentTimeInMs, expectedTime),
-				c.BoundRule(), "")
+				fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
 		}
 	}
 }

--- a/core/hotspot/traffic_shaping.go
+++ b/core/hotspot/traffic_shaping.go
@@ -87,14 +87,14 @@ func (c *baseTrafficShapingController) performCheckingForConcurrencyMetric(arg i
 			return nil
 		}
 		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-			fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
+			fmt.Sprintf("arg=%v", arg), c.BoundRule(), concurrency)
 	}
 	threshold := int64(c.threshold)
 	if concurrency <= threshold {
 		return nil
 	}
 	return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow,
-		fmt.Sprintf("arg=%v", arg), c.BoundRule(), nil)
+		fmt.Sprintf("arg=%v", arg), c.BoundRule(), concurrency)
 }
 
 // rejectTrafficShapingController use Reject strategy

--- a/core/system/slot.go
+++ b/core/system/slot.go
@@ -17,14 +17,14 @@ func (s *SystemAdaptiveSlot) Check(ctx *base.EntryContext) *base.TokenResult {
 	rules := GetRules()
 	result := ctx.RuleCheckResult
 	for _, rule := range rules {
-		passed, m := s.doCheckRule(rule)
+		passed, snapshotValue := s.doCheckRule(rule)
 		if passed {
 			continue
 		}
 		if result == nil {
-			result = base.NewTokenResultBlockedWithCause(base.BlockTypeSystemFlow, base.BlockTypeSystemFlow.String(), rule, m)
+			result = base.NewTokenResultBlockedWithCause(base.BlockTypeSystemFlow, rule.MetricType.String(), rule, snapshotValue)
 		} else {
-			result.ResetToBlockedWithCauseFrom(base.BlockTypeSystemFlow, base.BlockTypeSystemFlow.String(), rule, m)
+			result.ResetToBlockedWithCause(base.BlockTypeSystemFlow, rule.MetricType.String(), rule, snapshotValue)
 		}
 		return result
 	}


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Improve all rule checking slots with standard `BlockError` representation.

### Does this pull request fix one issue?

NONE

### Describe how you did it

This PR follows a simple BlockError specification:

- The `Error()` SHOULD start with `SentinelBlockError: ${blockType}`. If block message is provided, append it to the `Error()` value. The `blockMsg` is not required.
- It's recommended to carry the triggered rule and the "snapshot" value in the `BlockError`.

This PR improves all rule checking slots with more standard `BlockError` representation.

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE