### PR TITLE
Optimize the way to initialize the start time of the AtomicBucketWrapArray

### DIFF
--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -197,12 +197,16 @@ func newSlowRtCircuitBreakerWithStat(r *slowRtRule, stat *slowRequestLeapArray) 
 	}
 }
 
-func newSlowRtCircuitBreaker(r *slowRtRule) *slowRtCircuitBreaker {
+func newSlowRtCircuitBreaker(r *slowRtRule) (*slowRtCircuitBreaker, error) {
 	interval := r.StatIntervalMs
 	stat := &slowRequestLeapArray{}
-	stat.data = sbase.NewLeapArray(1, interval, stat)
+	leapArray, err := sbase.NewLeapArray(1, interval, stat)
+	if err != nil {
+		return nil, err
+	}
+	stat.data = leapArray
 
-	return newSlowRtCircuitBreakerWithStat(r, stat)
+	return newSlowRtCircuitBreakerWithStat(r, stat), nil
 }
 
 func (b *slowRtCircuitBreaker) BoundStat() interface{} {
@@ -379,12 +383,15 @@ func newErrorRatioCircuitBreakerWithStat(r *errorRatioRule, stat *errorCounterLe
 	}
 }
 
-func newErrorRatioCircuitBreaker(r *errorRatioRule) *errorRatioCircuitBreaker {
+func newErrorRatioCircuitBreaker(r *errorRatioRule) (*errorRatioCircuitBreaker, error) {
 	interval := r.StatIntervalMs
 	stat := &errorCounterLeapArray{}
-	stat.data = sbase.NewLeapArray(1, interval, stat)
-
-	return newErrorRatioCircuitBreakerWithStat(r, stat)
+	leapArray, err := sbase.NewLeapArray(1, interval, stat)
+	if err != nil {
+		return nil, err
+	}
+	stat.data = leapArray
+	return newErrorRatioCircuitBreakerWithStat(r, stat), nil
 }
 
 func (b *errorRatioCircuitBreaker) BoundStat() interface{} {
@@ -556,12 +563,15 @@ func newErrorCountCircuitBreakerWithStat(r *errorCountRule, stat *errorCounterLe
 	}
 }
 
-func newErrorCountCircuitBreaker(r *errorCountRule) *errorCountCircuitBreaker {
+func newErrorCountCircuitBreaker(r *errorCountRule) (*errorCountCircuitBreaker, error) {
 	interval := r.StatIntervalMs
 	stat := &errorCounterLeapArray{}
-	stat.data = sbase.NewLeapArray(1, interval, stat)
-
-	return newErrorCountCircuitBreakerWithStat(r, stat)
+	leapArray, err := sbase.NewLeapArray(1, interval, stat)
+	if err != nil {
+		return nil, err
+	}
+	stat.data = leapArray
+	return newErrorCountCircuitBreakerWithStat(r, stat), nil
 }
 
 func (b *errorCountCircuitBreaker) BoundStat() interface{} {

--- a/core/stat/base/bucket_leap_array_test.go
+++ b/core/stat/base/bucket_leap_array_test.go
@@ -95,7 +95,7 @@ func coroutineTask(wg *sync.WaitGroup, slidingWindow *BucketLeapArray, now uint6
 
 func TestBucketLeapArray_resetBucketTo(t *testing.T) {
 	bla := NewBucketLeapArray(SampleCount, IntervalInMs)
-	idx := 6
+	idx := 19
 	oldBucketWrap := bla.data.array.get(idx)
 	oldBucket := oldBucketWrap.Value.Load()
 	if oldBucket == nil {

--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -49,34 +49,48 @@ type AtomicBucketWrapArray struct {
 	data   []*BucketWrap
 }
 
-// New AtomicBucketWrapArray with initializing field data
-// Default, automatically initialize each BucketWrap
-// len: length of array
-// bucketLengthInMs: bucket length of BucketWrap
-// generator: generator to generate bucket
-func NewAtomicBucketWrapArray(len int, bucketLengthInMs uint32, generator BucketGenerator) *AtomicBucketWrapArray {
+func NewAtomicBucketWrapArrayWithTime(len int, bucketLengthInMs uint32, now uint64, generator BucketGenerator) *AtomicBucketWrapArray {
 	ret := &AtomicBucketWrapArray{
 		length: len,
 		data:   make([]*BucketWrap, len),
 	}
 
-	// automatically initialize each BucketWrap
-	// tail BucketWrap of data is initialized with current time
-	startTime := calculateStartTime(util.CurrentTimeMillis(), bucketLengthInMs)
-	for i := len - 1; i >= 0; i-- {
+	timeId := now / uint64(bucketLengthInMs)
+	idx := int(timeId) % len
+	startTime := calculateStartTime(now, bucketLengthInMs)
+
+	for i := idx; i <= len-1; i++ {
 		ww := &BucketWrap{
 			BucketStart: startTime,
 			Value:       atomic.Value{},
 		}
 		ww.Value.Store(generator.NewEmptyBucket())
 		ret.data[i] = ww
-		startTime -= uint64(bucketLengthInMs)
+		startTime += uint64(bucketLengthInMs)
+	}
+	for i := 0; i < idx; i++ {
+		ww := &BucketWrap{
+			BucketStart: startTime,
+			Value:       atomic.Value{},
+		}
+		ww.Value.Store(generator.NewEmptyBucket())
+		ret.data[i] = ww
+		startTime += uint64(bucketLengthInMs)
 	}
 
 	// calculate base address for real data array
 	sliHeader := (*util.SliceHeader)(unsafe.Pointer(&ret.data))
 	ret.base = unsafe.Pointer((**BucketWrap)(unsafe.Pointer(sliHeader.Data)))
 	return ret
+}
+
+// New AtomicBucketWrapArray with initializing field data
+// Default, automatically initialize each BucketWrap
+// len: length of array
+// bucketLengthInMs: bucket length of BucketWrap
+// generator: generator to generate bucket
+func NewAtomicBucketWrapArray(len int, bucketLengthInMs uint32, generator BucketGenerator) *AtomicBucketWrapArray {
+	return NewAtomicBucketWrapArrayWithTime(len, bucketLengthInMs, util.CurrentTimeMillis(), generator)
 }
 
 func (aa *AtomicBucketWrapArray) elementOffset(idx int) unsafe.Pointer {
@@ -103,7 +117,14 @@ func (aa *AtomicBucketWrapArray) compareAndSet(idx int, except, update *BucketWr
 // The BucketWrap leap array,
 // sampleCount represent the number of BucketWrap
 // intervalInMs represent the interval of LeapArray.
-// For example, bucketLengthInMs is 500ms, intervalInMs is 1min, so sampleCount is 120.
+// For example, bucketLengthInMs is 200ms, intervalInMs is 1000ms, so sampleCount is 5.
+// Give a diagram to illustrate
+// Suppose current time is 888, bucketLengthInMs is 200ms, intervalInMs is 1000ms, LeapArray will build the below windows
+//   B0       B1      B2     B3      B4
+//   |_______|_______|_______|_______|_______|
+//  1000    1200    1400    1600    800    (1000)
+//                                        ^
+//                                      time=888
 type LeapArray struct {
 	bucketLengthInMs uint32
 	sampleCount      uint32
@@ -113,20 +134,20 @@ type LeapArray struct {
 	updateLock mutex
 }
 
-func NewLeapArray(sampleCount uint32, intervalInMs uint32, generator BucketGenerator) *LeapArray {
+func NewLeapArray(sampleCount uint32, intervalInMs uint32, generator BucketGenerator) (*LeapArray, error) {
 	if intervalInMs%sampleCount != 0 {
-		panic(fmt.Sprintf("Invalid parameters, intervalInMs is %d, sampleCount is %d.", intervalInMs, sampleCount))
+		return nil, errors.Errorf("Invalid parameters, intervalInMs is %d, sampleCount is %d", intervalInMs, sampleCount)
 	}
 	if generator == nil {
-		panic("Invalid parameters, generator is nil.")
+		return nil, errors.Errorf("Invalid parameters, BucketGenerator is nil")
 	}
 	bucketLengthInMs := intervalInMs / sampleCount
 	return &LeapArray{
 		bucketLengthInMs: bucketLengthInMs,
 		sampleCount:      sampleCount,
 		intervalInMs:     intervalInMs,
-		array:            NewAtomicBucketWrapArray(int(sampleCount), intervalInMs, generator),
-	}
+		array:            NewAtomicBucketWrapArray(int(sampleCount), bucketLengthInMs, generator),
+	}, nil
 }
 
 func (la *LeapArray) CurrentBucket(bg BucketGenerator) (*BucketWrap, error) {

--- a/core/stat/base/leap_array_test.go
+++ b/core/stat/base/leap_array_test.go
@@ -32,10 +32,6 @@ func Test_bucketWrapper_Size(t *testing.T) {
 	}
 }
 
-//type metricBucketMock struct {
-//	mock.Mock
-//}
-
 // mock ArrayMock and implement BucketGenerator
 type leapArrayMock struct {
 	mock.Mock
@@ -132,122 +128,24 @@ func Test_calculateStartTime_normal(t *testing.T) {
 }
 
 func Test_leapArray_BucketStartCheck_normal(t *testing.T) {
-	type fields struct {
-		BucketLengthInMs uint32
-		sampleCount      uint32
-		intervalInMs     uint32
-		array            *AtomicBucketWrapArray
-		mux              mutex
+	now := uint64(1596199310000)
+	la := &LeapArray{
+		bucketLengthInMs: BucketLengthInMs,
+		sampleCount:      SampleCount,
+		intervalInMs:     IntervalInMs,
+		array:            NewAtomicBucketWrapArrayWithTime(int(SampleCount), BucketLengthInMs, now, &leapArrayMock{}),
+		updateLock:       mutex{},
 	}
-	type args struct {
-		bg         BucketGenerator
-		timeMillis uint64
+	got, err := la.currentBucketOfTime(now+801, new(leapArrayMock))
+	if err != nil {
+		t.Errorf("LeapArray.currentBucketOfTime() error = %v\n", err)
+		return
 	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   uint64 //start time of bucket
-	}{
-		{
-			name: "Test_leapArray_BucketStartCheck_normal",
-			fields: fields{
-				BucketLengthInMs: BucketLengthInMs,
-				sampleCount:      SampleCount,
-				intervalInMs:     IntervalInMs,
-				array:            NewAtomicBucketWrapArray(int(SampleCount), BucketLengthInMs, &leapArrayMock{}),
-				mux:              mutex{},
-			},
-			args: args{
-				bg:         new(leapArrayMock),
-				timeMillis: 1576296044907,
-			},
-			want: 1576296044500,
-		},
+	if got.BucketStart != now+500 {
+		t.Errorf("BucketStart = %v, want %v", got.BucketStart, now+500)
 	}
-	wwPtr := tests[0].fields.array.get(9)
-	wwPtr.BucketStart = 1576296044500 //start time of cycle 1576296040000
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			la := &LeapArray{
-				bucketLengthInMs: tt.fields.BucketLengthInMs,
-				sampleCount:      tt.fields.sampleCount,
-				intervalInMs:     tt.fields.intervalInMs,
-				array:            tt.fields.array,
-				updateLock:       tt.fields.mux,
-			}
-			got, err := la.currentBucketOfTime(tt.args.timeMillis, tt.args.bg)
-			if err != nil {
-				t.Errorf("LeapArray.currentBucketOfTime() error = %v\n", err)
-				return
-			}
-			if got.BucketStart != tt.want {
-				t.Errorf("BucketStart = %v, want %v", got.BucketStart, tt.want)
-			}
-		})
-	}
-}
-
-func Test_leapArray_currentBucketWithTime_normal(t *testing.T) {
-	type fields struct {
-		bucketLengthInMs uint32
-		sampleCount      uint32
-		intervalInMs     uint32
-		array            *AtomicBucketWrapArray
-		mux              mutex
-	}
-	type args struct {
-		bg         BucketGenerator
-		timeMillis uint64
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *BucketWrap
-		wantErr bool
-	}{
-		{
-			name: "Test_leapArray_currentBucketWithTime_normal",
-			fields: fields{
-				bucketLengthInMs: BucketLengthInMs,
-				sampleCount:      SampleCount,
-				intervalInMs:     IntervalInMs,
-				array:            NewAtomicBucketWrapArray(int(SampleCount), BucketLengthInMs, &leapArrayMock{}),
-				mux:              mutex{},
-			},
-			args: args{
-				bg:         new(leapArrayMock),
-				timeMillis: 1576296044907,
-			},
-			want:    nil,
-			wantErr: false,
-		},
-	}
-
-	wwPtr := tests[0].fields.array.get(9)
-	wwPtr.BucketStart = 1576296044500 //start time of cycle 1576296040000
-	tests[0].want = tests[0].fields.array.get(9)
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			la := &LeapArray{
-				bucketLengthInMs: tt.fields.bucketLengthInMs,
-				sampleCount:      tt.fields.sampleCount,
-				intervalInMs:     tt.fields.intervalInMs,
-				array:            tt.fields.array,
-				updateLock:       tt.fields.mux,
-			}
-			got, err := la.currentBucketOfTime(tt.args.timeMillis, tt.args.bg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LeapArray.currentBucketOfTime() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LeapArray.currentBucketOfTime() = %v, want %v", got, tt.want)
-			}
-		})
+	if !reflect.DeepEqual(got, la.array.get(1)) {
+		t.Errorf("LeapArray.currentBucketOfTime() = %v, want %v", got, la.array.get(1))
 	}
 }
 
@@ -275,7 +173,7 @@ func Test_leapArray_valuesWithTime_normal(t *testing.T) {
 				bucketLengthInMs: BucketLengthInMs,
 				sampleCount:      SampleCount,
 				intervalInMs:     IntervalInMs,
-				array:            NewAtomicBucketWrapArray(int(SampleCount), BucketLengthInMs, &leapArrayMock{}),
+				array:            NewAtomicBucketWrapArrayWithTime(int(SampleCount), BucketLengthInMs, uint64(1596199310000), &leapArrayMock{}),
 				mux:              mutex{},
 			},
 			args: args{
@@ -344,7 +242,7 @@ func Test_leapArray_isBucketDeprecated_normal(t *testing.T) {
 				bucketLengthInMs: BucketLengthInMs,
 				sampleCount:      SampleCount,
 				intervalInMs:     IntervalInMs,
-				array:            NewAtomicBucketWrapArray(int(SampleCount), BucketLengthInMs, &leapArrayMock{}),
+				array:            NewAtomicBucketWrapArrayWithTime(int(SampleCount), BucketLengthInMs, uint64(1596199310000), &leapArrayMock{}),
 				mux:              mutex{},
 			},
 			args: args{


### PR DESCRIPTION
### Describe what this PR does / why we need it
Make the start time of AtomicBucketWrapArray align to standard time.
Fix the typo in NewLeapArray.

### Does this pull request fix one issue?


### Describe how you did it


### Describe how to verify it


### Special notes for reviews