### PR TITLE
fix circuit breaker half-open state issue.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -140,6 +140,7 @@ func entry(resource string, options *EntryOptions) (*base.SentinelEntry, *base.B
 	options.Reset()
 	entryOptsPool.Put(options)
 	e := base.NewSentinelEntry(ctx, rw, sc)
+	ctx.SetEntry(e)
 	r := sc.Entry(ctx)
 	if r == nil {
 		// This indicates internal error in some slots, so just pass

--- a/core/base/context.go
+++ b/core/base/context.go
@@ -3,7 +3,8 @@ package base
 import "github.com/alibaba/sentinel-golang/util"
 
 type EntryContext struct {
-	// internal error when sentinel entry or
+	entry *SentinelEntry
+	// internal error when sentinel Entry or
 	// biz error of downstream
 	err error
 	// Use to calculate RT
@@ -19,6 +20,14 @@ type EntryContext struct {
 	RuleCheckResult *TokenResult
 	// reserve for storing some intermediate data from the Entry execution process
 	Data map[interface{}]interface{}
+}
+
+func (ctx *EntryContext) SetEntry(entry *SentinelEntry) {
+	ctx.entry = entry
+}
+
+func (ctx *EntryContext) Entry() *SentinelEntry {
+	return ctx.entry
 }
 
 func (ctx *EntryContext) Err() error {
@@ -79,6 +88,7 @@ func (i *SentinelInput) reset() {
 // Reset init EntryContext,
 func (ctx *EntryContext) Reset() {
 	// reset all fields of ctx
+	ctx.entry = nil
 	ctx.err = nil
 	ctx.startTime = 0
 	ctx.rt = 0

--- a/core/base/entry_test.go
+++ b/core/base/entry_test.go
@@ -1,1 +1,27 @@
 package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var flag = 0
+
+func exitHandlerMock(entry *SentinelEntry, ctx *EntryContext) error {
+	flag += 1
+	return nil
+}
+
+func TestSentinelEntry_WhenExit(t *testing.T) {
+	flag = 0
+	sc := NewSlotChain()
+	ctx := sc.GetPooledContext()
+	entry := NewSentinelEntry(ctx, nil, sc)
+	entry.WhenExit(exitHandlerMock)
+	entry.Exit()
+	assert.True(t, flag == 1)
+
+	entry.Exit()
+	assert.True(t, flag == 1)
+}

--- a/core/base/slot_chain.go
+++ b/core/base/slot_chain.go
@@ -40,8 +40,9 @@ type StatSlot interface {
 	// StatSlots will do some statistic logic, such as QPS、log、etc
 	// blockError introduce the block detail
 	OnEntryBlocked(ctx *EntryContext, blockError *BlockError)
-	// onComplete function will be invoked when chain exits.
-	// The request may be executed successful or blocked or internal error
+	// OnCompleted function will be invoked when chain exits.
+	// The semantics of OnCompleted is the entry passed and completed
+	// Note: blocked entry will not call this function
 	OnCompleted(ctx *EntryContext)
 }
 

--- a/core/base/slot_chain_test.go
+++ b/core/base/slot_chain_test.go
@@ -220,6 +220,7 @@ func TestSlotChain_Entry_Pass_And_Exit(t *testing.T) {
 	ctx := sc.GetPooledContext()
 	rw := NewResourceWrapper("abc", ResTypeCommon, Inbound)
 	ctx.Resource = rw
+	ctx.SetEntry(NewSentinelEntry(ctx, rw, sc))
 	ctx.StatNode = &StatNodeMock{}
 	ctx.Input = &SentinelInput{
 		AcquireCount: 1,
@@ -261,6 +262,7 @@ func TestSlotChain_Entry_Block(t *testing.T) {
 	sc := NewSlotChain()
 	ctx := sc.GetPooledContext()
 	rw := NewResourceWrapper("abc", ResTypeCommon, Inbound)
+	ctx.SetEntry(NewSentinelEntry(ctx, rw, sc))
 	ctx.Resource = rw
 	ctx.StatNode = &StatNodeMock{}
 	ctx.Input = &SentinelInput{

--- a/core/circuitbreaker/rule.go
+++ b/core/circuitbreaker/rule.go
@@ -79,7 +79,7 @@ func (b *RuleBase) IsApplicable() error {
 	if b.RetryTimeoutMs <= 0 {
 		return errors.New("invalid RetryTimeoutMs")
 	}
-	if b.MinRequestAmount <= 0 {
+	if b.MinRequestAmount < 0 {
 		return errors.New("invalid MinRequestAmount")
 	}
 	if b.StatIntervalMs <= 0 {

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -284,6 +284,8 @@ func RegisterStateChangeListeners(listeners ...StateChangeListener) {
 	stateChangeListeners = append(stateChangeListeners, listeners...)
 }
 
+// ClearStateChangeListeners will clear the all StateChangeListener
+// Note: this function is not thread-safe.
 func ClearStateChangeListeners() {
 	stateChangeListeners = make([]StateChangeListener, 0)
 }

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -274,12 +274,11 @@ func logRuleUpdate(rules map[string][]Rule) {
 	logging.Info(sb.String())
 }
 
+// Note: this function is not thread-safe.
 func RegisterStateChangeListeners(listeners ...StateChangeListener) {
 	if len(listeners) == 0 {
 		return
 	}
-	updateMux.Lock()
-	defer updateMux.Unlock()
 
 	stateChangeListeners = append(stateChangeListeners, listeners...)
 }

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -284,6 +284,10 @@ func RegisterStateChangeListeners(listeners ...StateChangeListener) {
 	stateChangeListeners = append(stateChangeListeners, listeners...)
 }
 
+func ClearStateChangeListeners() {
+	stateChangeListeners = make([]StateChangeListener, 0)
+}
+
 // SetCircuitBreakerGenerator sets the circuit breaker generator for the given strategy.
 // Note that modifying the generator of default strategies is not allowed.
 func SetCircuitBreakerGenerator(s Strategy, generator CircuitBreakerGenFunc) error {

--- a/tests/core/circuitbreaker/circuitbreaker_slot_integration_test.go
+++ b/tests/core/circuitbreaker/circuitbreaker_slot_integration_test.go
@@ -1,0 +1,286 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sentinel "github.com/alibaba/sentinel-golang/api"
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/core/circuitbreaker"
+	"github.com/alibaba/sentinel-golang/core/config"
+	"github.com/alibaba/sentinel-golang/logging"
+	"github.com/alibaba/sentinel-golang/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type StateChangeListenerMock struct {
+	mock.Mock
+}
+
+func (s *StateChangeListenerMock) OnTransformToClosed(prev circuitbreaker.State, rule circuitbreaker.Rule) {
+	_ = s.Called(prev, rule)
+	fmt.Printf("rule.steategy: %+v, From %s to Closed, time: %d\n", rule.BreakerStrategy(), prev.String(), util.CurrentTimeMillis())
+	return
+}
+
+func (s *StateChangeListenerMock) OnTransformToOpen(prev circuitbreaker.State, rule circuitbreaker.Rule, snapshot interface{}) {
+	_ = s.Called(prev, rule, snapshot)
+	fmt.Printf("rule.steategy: %+v, From %s to Open, snapshot: %.2f, time: %d\n", rule.BreakerStrategy(), prev.String(), snapshot, util.CurrentTimeMillis())
+}
+
+func (s *StateChangeListenerMock) OnTransformToHalfOpen(prev circuitbreaker.State, rule circuitbreaker.Rule) {
+	_ = s.Called(prev, rule)
+	fmt.Printf("rule.steategy: %+v, From %s to Half-Open, time: %d\n", rule.BreakerStrategy(), prev.String(), util.CurrentTimeMillis())
+}
+
+// Test scenario
+// circuit breaker1: slow rt, max rt: 3ms, retry timeout: 1ms, slowRt threshold: 0.1
+// circuit breaker2: error ratio, retry timeout: 2000000+ms, error ratio threshold: 0.1
+// First request: make cb1 and cb2 trigger fusing
+// Second request: make cb1 retry and change state from open to halfOpen, but this request is blocked by cb2.
+//                 when request exit, rollback the state of cb1 to open
+// Third request: same with second request.
+func TestCircuitBreakerSlotIntegration_Normal(t *testing.T) {
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+
+	conf := config.NewDefaultConfig()
+	conf.Sentinel.Log.Logger = logging.NewConsoleLogger("cb-integration-normal")
+	err := sentinel.InitWithConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cbRule1 := circuitbreaker.NewRule("abc", circuitbreaker.SlowRequestRatio,
+		circuitbreaker.WithStatIntervalMs(10000), circuitbreaker.WithRetryTimeoutMs(1),
+		circuitbreaker.WithMinRequestAmount(0), circuitbreaker.WithMaxAllowedRtMs(3),
+		circuitbreaker.WithMaxSlowRequestRatio(0.1))
+	// Statistic time span=10s, recoveryTimeout=3s, maxErrorRatio=50%
+	cbRule2 := circuitbreaker.NewRule("abc", circuitbreaker.ErrorRatio,
+		circuitbreaker.WithStatIntervalMs(10000), circuitbreaker.WithRetryTimeoutMs(2000000),
+		circuitbreaker.WithMinRequestAmount(0), circuitbreaker.WithErrorRatioThreshold(0.1))
+
+	_, err = circuitbreaker.LoadRules([]circuitbreaker.Rule{cbRule1, cbRule2})
+	stateListener := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := base.NewSlotChain()
+	sc.AddRuleCheckSlotLast(&circuitbreaker.Slot{})
+	sc.AddStatSlotLast(&circuitbreaker.MetricStatSlot{})
+
+	stateListener.On("OnTransformToOpen", circuitbreaker.Closed, mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToHalfOpen", mock.Anything, mock.Anything).Return()
+
+	// First trigger the circuit breaker
+	e, b := sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	assert.True(t, b == nil)
+	sentinel.TraceError(e, errors.New("biz error"))
+	time.Sleep(time.Duration(50) * time.Millisecond)
+	e.Exit()
+	stateListener.AssertNumberOfCalls(t, "OnTransformToOpen", 2)
+	stateListener.AssertNotCalled(t, "OnTransformToClosed")
+	stateListener.AssertNotCalled(t, "OnTransformToHalfOpen")
+
+	// wait circuit breaker1 retry timeout
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	// Second circuit breaker1 probes and circuit breaker2 block the request
+	circuitbreaker.ClearStateChangeListeners()
+	stateListener2 := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener2)
+	stateListener2.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener2.On("OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything).Return()
+	stateListener2.On("OnTransformToHalfOpen", circuitbreaker.Open, cbRule1).Return()
+	e, b = sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	assert.True(t, b != nil && b.BlockType() == base.BlockTypeCircuitBreaking && reflect.DeepEqual(b.TriggeredRule(), cbRule2))
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToHalfOpen", 1)
+	stateListener2.AssertCalled(t, "OnTransformToHalfOpen", circuitbreaker.Open, cbRule1)
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToOpen", 1)
+	stateListener2.AssertCalled(t, "OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything)
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	// Third, same with second request.
+	circuitbreaker.ClearStateChangeListeners()
+	stateListener3 := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener3)
+	stateListener3.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener3.On("OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything).Return()
+	stateListener3.On("OnTransformToHalfOpen", circuitbreaker.Open, cbRule1).Return()
+	e, b = sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	assert.True(t, b != nil && b.BlockType() == base.BlockTypeCircuitBreaking && reflect.DeepEqual(b.TriggeredRule(), cbRule2))
+	stateListener3.AssertNumberOfCalls(t, "OnTransformToHalfOpen", 1)
+	stateListener3.AssertCalled(t, "OnTransformToHalfOpen", circuitbreaker.Open, cbRule1)
+	stateListener3.AssertNumberOfCalls(t, "OnTransformToOpen", 1)
+	stateListener3.AssertCalled(t, "OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything)
+
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+}
+
+func TestCircuitBreakerSlotIntegration_Probe_Succeed(t *testing.T) {
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+
+	conf := config.NewDefaultConfig()
+	conf.Sentinel.Log.Logger = logging.NewConsoleLogger("cb-integration-probe-succeed")
+	err := sentinel.InitWithConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cbRule1 := circuitbreaker.NewRule("abc", circuitbreaker.SlowRequestRatio,
+		circuitbreaker.WithStatIntervalMs(10000), circuitbreaker.WithRetryTimeoutMs(20),
+		circuitbreaker.WithMinRequestAmount(0), circuitbreaker.WithMaxAllowedRtMs(3),
+		circuitbreaker.WithMaxSlowRequestRatio(0.1))
+
+	_, err = circuitbreaker.LoadRules([]circuitbreaker.Rule{cbRule1})
+	stateListener := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := base.NewSlotChain()
+	sc.AddRuleCheckSlotLast(&circuitbreaker.Slot{})
+	sc.AddStatSlotLast(&circuitbreaker.MetricStatSlot{})
+
+	stateListener.On("OnTransformToOpen", circuitbreaker.Closed, mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToHalfOpen", mock.Anything, mock.Anything).Return()
+
+	// First trigger the circuit breaker
+	e, b := sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	assert.True(t, b == nil)
+	time.Sleep(time.Duration(50) * time.Millisecond)
+	e.Exit()
+	stateListener.AssertNumberOfCalls(t, "OnTransformToOpen", 1)
+	stateListener.AssertNotCalled(t, "OnTransformToClosed")
+	stateListener.AssertNotCalled(t, "OnTransformToHalfOpen")
+
+	// wait circuit breaker1 retry timeout
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	// Second circuit breaker1 probes succeed
+	circuitbreaker.ClearStateChangeListeners()
+	stateListener2 := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener2)
+	stateListener2.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener2.On("OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything).Return()
+	stateListener2.On("OnTransformToHalfOpen", circuitbreaker.Open, cbRule1).Return()
+	e, b = sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	e.Exit()
+	assert.True(t, b == nil)
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToHalfOpen", 1)
+	stateListener2.AssertCalled(t, "OnTransformToHalfOpen", circuitbreaker.Open, cbRule1)
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToClosed", 1)
+	stateListener2.AssertCalled(t, "OnTransformToClosed", circuitbreaker.HalfOpen, cbRule1)
+
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+}
+
+func TestCircuitBreakerSlotIntegration_Concurrency(t *testing.T) {
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+	conf := config.NewDefaultConfig()
+	conf.Sentinel.Log.Logger = logging.NewConsoleLogger("cb-integration-concurrency")
+	err := sentinel.InitWithConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cbRule1 := circuitbreaker.NewRule("abc", circuitbreaker.SlowRequestRatio,
+		circuitbreaker.WithStatIntervalMs(100000), circuitbreaker.WithRetryTimeoutMs(1),
+		circuitbreaker.WithMinRequestAmount(0), circuitbreaker.WithMaxAllowedRtMs(3),
+		circuitbreaker.WithMaxSlowRequestRatio(0.1))
+	// Statistic time span=10s, recoveryTimeout=3s, maxErrorRatio=50%
+	cbRule2 := circuitbreaker.NewRule("abc", circuitbreaker.ErrorRatio,
+		circuitbreaker.WithStatIntervalMs(100000), circuitbreaker.WithRetryTimeoutMs(2000000),
+		circuitbreaker.WithMinRequestAmount(0), circuitbreaker.WithErrorRatioThreshold(0.1))
+
+	_, err = circuitbreaker.LoadRules([]circuitbreaker.Rule{cbRule1, cbRule2})
+	stateListener := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := base.NewSlotChain()
+	sc.AddRuleCheckSlotLast(&circuitbreaker.Slot{})
+	sc.AddStatSlotLast(&circuitbreaker.MetricStatSlot{})
+
+	stateListener.On("OnTransformToOpen", circuitbreaker.Closed, mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener.On("OnTransformToHalfOpen", mock.Anything, mock.Anything).Return()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(100)
+
+	// First trigger the circuit breaker1 and circuit breaker2
+	e, b := sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+	assert.True(t, b == nil)
+	sentinel.TraceError(e, errors.New("biz error"))
+	time.Sleep(time.Duration(50) * time.Millisecond)
+	e.Exit()
+	stateListener.AssertNumberOfCalls(t, "OnTransformToOpen", 2)
+	stateListener.AssertNotCalled(t, "OnTransformToClosed")
+	stateListener.AssertNotCalled(t, "OnTransformToHalfOpen")
+	// wait circuit breaker1 retry timeout
+	time.Sleep(time.Duration(100) * time.Millisecond)
+
+	circuitbreaker.ClearStateChangeListeners()
+	stateListener2 := &StateChangeListenerMock{}
+	circuitbreaker.RegisterStateChangeListeners(stateListener2)
+	stateListener2.On("OnTransformToClosed", mock.Anything, mock.Anything).Return()
+	stateListener2.On("OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything).Return()
+	stateListener2.On("OnTransformToHalfOpen", circuitbreaker.Open, cbRule1).Return()
+
+	probeFailedCount := int64(0)
+	for i := 0; i < 100; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				e, b := sentinel.Entry("abc", sentinel.WithSlotChain(sc))
+				assert.True(t, b != nil)
+				if reflect.DeepEqual(b.TriggeredRule(), cbRule2) {
+					atomic.AddInt64(&probeFailedCount, 1)
+				}
+				if b == nil {
+					e.Exit()
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	stateListener2.AssertCalled(t, "OnTransformToHalfOpen", circuitbreaker.Open, cbRule1)
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToHalfOpen", int(atomic.LoadInt64(&probeFailedCount)))
+	stateListener2.AssertCalled(t, "OnTransformToOpen", circuitbreaker.HalfOpen, cbRule1, mock.Anything)
+	stateListener2.AssertNumberOfCalls(t, "OnTransformToOpen", int(atomic.LoadInt64(&probeFailedCount)))
+
+	fmt.Println("slow rt rule probe failed: ", atomic.LoadInt64(&probeFailedCount))
+	circuitbreaker.ClearStateChangeListeners()
+	if clearErr := circuitbreaker.ClearRules(); clearErr != nil {
+		t.Fatal(clearErr)
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix the issue: #196 
add defer to handle panic in entry.Exit func and move context recovery logic to defer

### Does this pull request fix one issue?
#196 

### Describe how you did it


### Describe how to verify it
UT and integration test
tests/core/circuitbreaker/circuitbreaker_slot_integration_test.go 
### Special notes for reviews