### PR TITLE
Refine api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -150,7 +150,7 @@ func entry(resource string, options *EntryOptions) (*base.SentinelEntry, *base.B
 		// must finish the lifecycle of r.
 		blockErr := base.NewBlockErrorFromDeepCopy(r.BlockError())
 		e.Exit()
-		return nil, blockErr
+		return e, blockErr
 	}
 
 	return e, nil

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -109,14 +109,13 @@ func Test_entryWithArgsAndChainBlock(t *testing.T) {
 	ssm.On("OnEntryBlocked", mock.Anything, mock.Anything).Return()
 	ssm.On("OnCompleted", mock.Anything).Return()
 
-	entry, b := entry("abc", &EntryOptions{
+	_, b := entry("abc", &EntryOptions{
 		resourceType: base.ResTypeCommon,
 		entryType:    base.Inbound,
 		acquireCount: 1,
 		flag:         0,
 		slotChain:    sc,
 	})
-	assert.Nil(t, entry)
 	assert.NotNil(t, b)
 	assert.Equal(t, blockType, b.BlockType())
 

--- a/api/tracer_test.go
+++ b/api/tracer_test.go
@@ -14,38 +14,13 @@ var (
 )
 
 func TestTraceErrorToEntry(t *testing.T) {
-	type args struct {
-		entry *base.SentinelEntry
-		err   error
-	}
 	te := errors.New("biz error")
-	tests := []struct {
-		name string
-		args args
-		want error
-	}{
-		{
-			name: "TestTraceErrorToEntry",
-			args: args{
-				entry: nil,
-				err:   nil,
-			},
-			want: te,
-		},
-	}
-
 	ctx := &base.EntryContext{
 		Resource: testRes,
 		Input:    nil,
 	}
-	tests[0].args.entry = base.NewSentinelEntry(ctx, testRes, nil)
-	tests[0].args.err = te
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			TraceError(tt.args.entry, tt.args.err)
-			time.Sleep(time.Millisecond * 10)
-			assert.Equal(t, tests[0].args.entry.Context().Err(), tt.want)
-		})
-	}
+	entry := base.NewSentinelEntry(ctx, testRes, nil)
+	TraceError(entry, te)
+	time.Sleep(time.Millisecond * 10)
+	assert.Equal(t, entry.Err(), te)
 }

--- a/core/base/entry.go
+++ b/core/base/entry.go
@@ -29,8 +29,11 @@ func (e *SentinelEntry) SetError(err error) {
 	}
 }
 
-func (e *SentinelEntry) Context() *EntryContext {
-	return e.ctx
+func (e *SentinelEntry) Err() error {
+	if e.ctx != nil {
+		return e.ctx.Err()
+	}
+	return nil
 }
 
 func (e *SentinelEntry) Resource() *ResourceWrapper {
@@ -56,6 +59,9 @@ func (e *SentinelEntry) Exit(exitOps ...ExitOption) {
 		opt(&options)
 	}
 	ctx := e.ctx
+	if ctx == nil {
+		return
+	}
 	if options.err != nil {
 		ctx.SetError(options.err)
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Currently, api.Entry() may return (nil, blockError).
Return nil is not user-friendly, normally, the user might use defer to perform Exit func, that causes panic.
Actually, we had done work to guarantee to exec Exit function exactly once.
From me perspective, I think to return entry is okay.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews