### PR TITLE
fix bug: incorrectly defined storeToken using uint in warmup flow control

### DIFF
--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -223,6 +223,9 @@ func checkControlBehaviorField(rule *FlowRule) error {
 		if rule.WarmUpPeriodSec <= 0 {
 			return errors.New("invalid warmUpPeriodSec")
 		}
+		if rule.WarmUpColdFactor == 1 {
+			return errors.New("WarmUpColdFactor must be great than 1")
+		}
 		return nil
 	case WarmUpThrottling:
 		if rule.WarmUpPeriodSec <= 0 {

--- a/example/warm_up/qps_warm_up_example.go
+++ b/example/warm_up/qps_warm_up_example.go
@@ -10,6 +10,7 @@ import (
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/flow"
+	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
 )
 
@@ -25,17 +26,19 @@ func main() {
 	counter := Counter{pass: new(int64), block: new(int64), total: new(int64)}
 	// We should initialize Sentinel first.
 	err := sentinel.InitDefault()
+	logging.ResetGlobalLogger(logging.NewConsoleLogger("flow-warmup-test"))
 	if err != nil {
 		log.Fatalf("Unexpected error: %+v", err)
 	}
 
 	_, err = flow.LoadRules([]*flow.FlowRule{
 		{
-			Resource:        "some-test",
-			MetricType:      flow.QPS,
-			Count:           100,
-			ControlBehavior: flow.WarmUp,
-			WarmUpPeriodSec: 10,
+			Resource:         "some-test",
+			MetricType:       flow.QPS,
+			Count:            100,
+			ControlBehavior:  flow.WarmUp,
+			WarmUpPeriodSec:  10,
+			WarmUpColdFactor: 3,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
### Describe what this PR does / why we need it
https://github.com/alibaba/sentinel-golang/blob/36a09c509daba8e3d790157f55af7587b688d39b/core/flow/tc_warm_up.go#L21

Define storedTokens as uint64 might cause bug.
https://github.com/alibaba/sentinel-golang/blob/36a09c509daba8e3d790157f55af7587b688d39b/core/flow/tc_warm_up.go#L78

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews