### PR TITLE
Remove field LimitOrigin in flow.Rule

### DIFF
--- a/core/flow/rule.go
+++ b/core/flow/rule.go
@@ -5,15 +5,6 @@ import (
 	"fmt"
 )
 
-const (
-	// LimitOriginDefault represents all origins.
-	LimitOriginDefault = "default"
-	// LimitOriginOther represents all origins excluding those configured in other rules.
-	// For example, if resource "abc" has a rule whose limit origin is "originA",
-	// the "other" origin will represents all origins excluding "originA".
-	LimitOriginOther = "other"
-)
-
 // MetricType represents the target metric type.
 type MetricType int32
 
@@ -50,19 +41,17 @@ type Rule struct {
 	ID uint64 `json:"id,omitempty"`
 
 	// Resource represents the resource name.
-	Resource string `json:"resource"`
-	// LimitOrigin represents the target origin (reserved field).
-	LimitOrigin string     `json:"limitOrigin"`
-	MetricType  MetricType `json:"metricType"`
+	Resource   string     `json:"resource"`
+	MetricType MetricType `json:"metricType"`
 	// Count represents the threshold.
-	Count            float64          `json:"count"`
-	RelationStrategy RelationStrategy `json:"relationStrategy"`
-	ControlBehavior  ControlBehavior  `json:"controlBehavior"`
+	Count           float64         `json:"count"`
+	ControlBehavior ControlBehavior `json:"controlBehavior"`
 
-	RefResource       string `json:"refResource"`
-	MaxQueueingTimeMs uint32 `json:"maxQueueingTimeMs"`
-	WarmUpPeriodSec   uint32 `json:"warmUpPeriodSec"`
-	WarmUpColdFactor  uint32 `json:"warmUpColdFactor"`
+	RelationStrategy  RelationStrategy `json:"relationStrategy"`
+	RefResource       string           `json:"refResource"`
+	MaxQueueingTimeMs uint32           `json:"maxQueueingTimeMs"`
+	WarmUpPeriodSec   uint32           `json:"warmUpPeriodSec"`
+	WarmUpColdFactor  uint32           `json:"warmUpColdFactor"`
 }
 
 func (f *Rule) String() string {

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -155,9 +155,6 @@ func buildFlowMap(rules []*Rule) TrafficControllerMap {
 			logging.Warnf("Ignoring invalid flow rule: %v, reason: %s", rule, err.Error())
 			continue
 		}
-		if rule.LimitOrigin == "" {
-			rule.LimitOrigin = LimitOriginDefault
-		}
 		generator, supported := tcGenFuncMap[rule.ControlBehavior]
 		if !supported {
 			logging.Warnf("Ignoring the rule due to unsupported control behavior: %v", rule)

--- a/ext/datasource/helper_test.go
+++ b/ext/datasource/helper_test.go
@@ -48,7 +48,6 @@ func TestFlowRulesJsonConverter(t *testing.T) {
 		assert.True(t, len(flowRules) == 3)
 		r1 := &flow.Rule{
 			Resource:          "abc",
-			LimitOrigin:       "default",
 			MetricType:        flow.Concurrency,
 			Count:             100,
 			RelationStrategy:  flow.Direct,
@@ -61,7 +60,6 @@ func TestFlowRulesJsonConverter(t *testing.T) {
 
 		r2 := &flow.Rule{
 			Resource:          "abc",
-			LimitOrigin:       "default",
 			MetricType:        flow.QPS,
 			Count:             200,
 			RelationStrategy:  flow.AssociatedResource,
@@ -74,7 +72,6 @@ func TestFlowRulesJsonConverter(t *testing.T) {
 
 		r3 := &flow.Rule{
 			Resource:          "abc",
-			LimitOrigin:       "default",
 			MetricType:        flow.QPS,
 			Count:             300,
 			RelationStrategy:  flow.Direct,
@@ -94,7 +91,6 @@ func TestFlowRulesUpdater(t *testing.T) {
 			{
 				ID:                0,
 				Resource:          "abc",
-				LimitOrigin:       "default",
 				MetricType:        0,
 				Count:             0,
 				RelationStrategy:  0,
@@ -127,7 +123,6 @@ func TestFlowRulesUpdater(t *testing.T) {
 		fw := flow.Rule{
 			ID:                0,
 			Resource:          "aaaa",
-			LimitOrigin:       "aaa",
 			MetricType:        0,
 			Count:             0,
 			RelationStrategy:  0,

--- a/tests/testdata/extension/helper/FlowRule.json
+++ b/tests/testdata/extension/helper/FlowRule.json
@@ -1,7 +1,6 @@
 [
     {
         "resource": "abc",
-        "limitOrigin": "default",
         "metricType": 0,
         "count": 100.0,
         "relationStrategy": 0,
@@ -12,7 +11,6 @@
     },
     {
         "resource": "abc",
-        "limitOrigin": "default",
         "metricType": 1,
         "count": 200.0,
         "relationStrategy": 1,
@@ -23,7 +21,6 @@
     },
     {
         "resource": "abc",
-        "limitOrigin": "default",
         "metricType": 1,
         "count": 300.0,
         "relationStrategy": 0,


### PR DESCRIPTION

### Describe what this PR does / why we need it
Remove field LimitOrigin in flow.Rule B/C LimitOrigin is redundancy

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
CI passs

### Special notes for reviews