### PR TITLE
Improve Config API

### DIFF
--- a/api/init.go
+++ b/api/init.go
@@ -9,6 +9,10 @@ import (
 	"github.com/alibaba/sentinel-golang/util"
 )
 
+// Initialization func initialize the Sentinel's runtime environment, including:
+// 		1. override global config, from manually config or yaml file or env variable
+//		2. override global logger
+// 		3. initiate core component async task, including: metric log, system statistic...
 // InitDefault initializes Sentinel using the configuration from system
 // environment and the default value.
 func InitDefault() error {
@@ -47,11 +51,16 @@ func InitWithConfigFile(configPath string) error {
 // initCoreComponents init core components with default config
 // it's better SetDefaultConfig before initCoreComponents
 func initCoreComponents() error {
-	if err := metric.InitTask(); err != nil {
-		return err
+	if config.MetricLogFlushIntervalSec() > 0 {
+		if err := metric.InitTask(); err != nil {
+			return err
+		}
 	}
 
-	system.InitCollector(config.SystemStatCollectIntervalMs())
+	if config.SystemStatCollectIntervalMs() > 0 {
+		system.InitCollector(config.SystemStatCollectIntervalMs())
+	}
+
 	if config.UseCacheTime() {
 		util.StartTimeTicker()
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -51,6 +51,7 @@ func OverrideConfigFromEnvAndInitLog() error {
 		return err
 	}
 
+	defer logging.Infof("effective global config: %+v", *globalCfg)
 	// Configured Logger is the highest priority
 	if configLogger := Logger(); configLogger != nil {
 		err = logging.ResetGlobalLogger(configLogger)
@@ -59,8 +60,12 @@ func OverrideConfigFromEnvAndInitLog() error {
 		}
 		return nil
 	}
-	err = initializeLogConfig(LogBaseDir(), LogUsePid())
-	if err != nil {
+
+	logDir := LogBaseDir()
+	if len(logDir) == 0 {
+		logDir = GetDefaultLogDir()
+	}
+	if err := initializeLogConfig(logDir, LogUsePid()); err != nil {
 		return err
 	}
 	logging.Infof("App name resolved: %s", AppName())

--- a/core/config/entity.go
+++ b/core/config/entity.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/pkg/errors"
 )
@@ -30,7 +33,7 @@ type SentinelConfig struct {
 
 // LogConfig represent the configuration of logging in Sentinel.
 type LogConfig struct {
-	// logger indicates that using logger to replace default logging.
+	// Logger indicates that using logger to replace default logging.
 	Logger logging.Logger
 	// Dir represents the log directory path.
 	Dir string
@@ -114,10 +117,15 @@ func checkConfValid(conf *SentinelConfig) error {
 	if mc.SingleFileMaxSize <= 0 {
 		return errors.New("Illegal metric log globalCfg: singleFileMaxSize <= 0")
 	}
-	if conf.Stat.System.CollectIntervalMs == 0 {
-		return errors.New("Bad system stat globalCfg: collectIntervalMs = 0")
-	}
 	return nil
+}
+
+func (entity *Entity) String() string {
+	e, err := json.Marshal(entity)
+	if err != nil {
+		return fmt.Sprintf("%+v", *entity)
+	}
+	return string(e)
 }
 
 func (entity *Entity) AppName() string {

--- a/core/log/metric/writer.go
+++ b/core/log/metric/writer.go
@@ -281,9 +281,10 @@ func NewDefaultMetricLogWriterOfApp(maxSize uint64, maxFileAmount uint32, appNam
 		return nil, errors.New("invalid maxSize or maxFileAmount")
 	}
 	_, offset := time.Now().Zone()
-	logDir := config.GetDefaultLogDir()
-	if len(config.LogBaseDir()) > 0 {
-		logDir = config.LogBaseDir()
+
+	logDir := config.LogBaseDir()
+	if len(logDir) == 0 {
+		logDir = config.GetDefaultLogDir()
 	}
 	baseDir := util.AddPathSeparatorIfAbsent(logDir)
 	baseFilename := FormMetricFileName(appName, config.LogUsePid())

--- a/core/log/metric/writer.go
+++ b/core/log/metric/writer.go
@@ -281,8 +281,11 @@ func NewDefaultMetricLogWriterOfApp(maxSize uint64, maxFileAmount uint32, appNam
 		return nil, errors.New("invalid maxSize or maxFileAmount")
 	}
 	_, offset := time.Now().Zone()
-
-	baseDir := util.AddPathSeparatorIfAbsent(config.LogBaseDir())
+	logDir := config.GetDefaultLogDir()
+	if len(config.LogBaseDir()) > 0 {
+		logDir = config.LogBaseDir()
+	}
+	baseDir := util.AddPathSeparatorIfAbsent(logDir)
 	baseFilename := FormMetricFileName(appName, config.LogUsePid())
 
 	writer := &DefaultMetricLogWriter{

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -20,7 +20,7 @@ const (
 )
 
 const (
-	DefaultNamespace = "default"
+	defaultNamespace = "sentinel-go"
 	// RecordLogFileName represents the default file name of the record log.
 	RecordLogFileName = "sentinel-record.log"
 	DefaultDirName    = "logs" + string(os.PathSeparator) + "csp" + string(os.PathSeparator)
@@ -28,7 +28,7 @@ const (
 
 var (
 	globalLogLevel = InfoLevel
-	globalLogger   = NewConsoleLogger(DefaultNamespace)
+	globalLogger   = NewConsoleLogger(defaultNamespace)
 )
 
 func GetGlobalLoggerLevel() Level {
@@ -64,7 +64,7 @@ func NewSimpleFileLogger(filepath, namespace string, flag int) (Logger, error) {
 	return &DefaultLogger{
 		log:       log.New(logFile, "", flag),
 		namespace: namespace,
-	}, err
+	}, nil
 }
 
 type Logger interface {


### PR DESCRIPTION
### Describe what this PR does / why we need it
Improve sentinel initialization mechanism

1. The logging module init function sets the default logger to be a file logger(sentinel-record.log). Even if the user does not initialize sentinel, it will work properly.
2. Reset logger by configEntity/yaml/default is optional. Reset logger only if the user sets logger in configuration.


### Does this pull request fix one issue?
None

### Describe how you did it


### Describe how to verify it
UT

### Special notes for reviews
@sczyh30 