### PR TITLE
Fix CI accidental failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install go ci lint
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
-    -name Test CI
+    - name: Test CI
       run: golangci-lint run -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
 
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
     - name: Test CI
-      run: golangci-lint run -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
+      run: golangci-lint run --timeout=10m -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
 
     - name: Test
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,11 +33,13 @@ jobs:
     - name: Install go ci lint
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
+    -name Test CI
+      run: golangci-lint run -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
+
     - name: Test
       run: |
         diff -u <(echo -n) <(gofmt -d -s .)
         diff -u <(echo -n) <(goimports -d .)
-        golangci-lint run -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
         go test -v -race ./... -coverprofile=coverage.txt -covermode=atomic
 
     - name: Coverage


### PR DESCRIPTION
### Describe what this PR does / why we need it
Because of golangci-lint's default timeout is 1m. It might cause CI failure.
 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews