### PR TITLE
Rule Manager: Make LoadRule() serialization and introduce recover logic when panic for LoadRules in circuit breaker module

### DIFF
--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -17,14 +17,18 @@ type CircuitBreakerGenFunc func(r *Rule, reuseStat interface{}) (CircuitBreaker,
 type actionType int8
 
 type ruleAction struct {
+	//The type of action associated with a rule.
 	action actionType
-	rules  []*Rule
-	wait   *sync.WaitGroup
+	//A set of rules for an operation.
+	rules []*Rule
+
+	wait *sync.WaitGroup
 }
 
 const (
+	//Load rule set
 	Load actionType = iota
-
+	//Clear rule set
 	Clear
 )
 
@@ -83,10 +87,13 @@ func init() {
 		}
 		return newErrorCountCircuitBreakerWithStat(r, stat), nil
 	}
-	go listen()
+
+	go listenRules()
 }
 
-func listen() {
+//Listening ruleChan
+//Depending on the action type, the relevant function is called.
+func listenRules() {
 	for {
 		ruleAction := <-ruleChan
 		switch ruleAction.action {

--- a/core/circuitbreaker/rule_manager_test.go
+++ b/core/circuitbreaker/rule_manager_test.go
@@ -141,7 +141,7 @@ func Test_onUpdateRules(t *testing.T) {
 			Threshold:        10,
 		}
 		rules = append(rules, r1, r2, r3)
-		err := onRuleUpdate(rules)
+		_, err := LoadRules(rules)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Enhance mutex and recover logic for LoadRules function in core module.
Reduce the granularity of locks

### Does this pull request fix one issue?

Fix:https://github.com/alibaba/sentinel-golang/issues/248

### Describe how you did it


### Describe how to verify it


### Special notes for reviews