### PR TITLE
Rule Manager:  Improve CircuitBreaker rule loading API (#236)

### DIFF
--- a/core/circuitbreaker/rule.go
+++ b/core/circuitbreaker/rule.go
@@ -17,6 +17,8 @@ const (
 	ErrorRatio
 	// ErrorCount strategy changes the circuit breaker state based on error amount
 	ErrorCount
+	// Last entry of strategies
+	UnsupportedStrategy
 )
 
 func (s Strategy) String() string {
@@ -76,7 +78,7 @@ func (r *Rule) ResourceName() string {
 	return r.Resource
 }
 
-func (r *Rule) isEqualsToBase(newRule *Rule) bool {
+func (r *Rule) equalsToBase(newRule *Rule) bool {
 	if newRule == nil {
 		return false
 	}
@@ -84,8 +86,8 @@ func (r *Rule) isEqualsToBase(newRule *Rule) bool {
 		r.MinRequestAmount == newRule.MinRequestAmount && r.StatIntervalMs == newRule.StatIntervalMs
 }
 
-func (r *Rule) isEqualsTo(newRule *Rule) bool {
-	if !r.isEqualsToBase(newRule) {
+func (r *Rule) equalsTo(newRule *Rule) bool {
+	if !r.equalsToBase(newRule) {
 		return false
 	}
 

--- a/example/circuitbreaker/circuit_breaker_example.go
+++ b/example/circuitbreaker/circuit_breaker_example.go
@@ -36,7 +36,7 @@ func main() {
 	// Register a state change listener so that we could observer the state change of the internal circuit breaker.
 	circuitbreaker.RegisterStateChangeListeners(&stateChangeTestListener{})
 
-	_, err = circuitbreaker.LoadRules([]*circuitbreaker.Rule{
+	_, err, _ = circuitbreaker.LoadRules([]*circuitbreaker.Rule{
 		// Statistic time span=10s, recoveryTimeout=3s, slowRtUpperBound=50ms, maxSlowRequestRatio=50%
 		{
 			Resource:         "abc",

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -130,8 +130,8 @@ func CircuitBreakerRulesUpdater(data interface{}) error {
 			desc: fmt.Sprintf("Fail to type assert data to []circuitbreaker.Rule, in fact, data: %+v", data),
 		}
 	}
-	succ, err := cb.LoadRules(rules)
-	if succ && err == nil {
+	succ, err, failedRules := cb.LoadRules(rules)
+	if succ && err == nil && len(failedRules) == 0 {
 		return nil
 	}
 	return Error{

--- a/tests/core/circuitbreaker/circuitbreaker_slot_integration_test.go
+++ b/tests/core/circuitbreaker/circuitbreaker_slot_integration_test.go
@@ -76,7 +76,7 @@ func TestCircuitBreakerSlotIntegration_Normal(t *testing.T) {
 		Threshold:        0.1,
 	}
 
-	_, err = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1, cbRule2})
+	_, err, _ = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1, cbRule2})
 	stateListener := &StateChangeListenerMock{}
 	circuitbreaker.RegisterStateChangeListeners(stateListener)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestCircuitBreakerSlotIntegration_Probe_Succeed(t *testing.T) {
 		Threshold:        0.1,
 	}
 
-	_, err = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1})
+	_, err, _ = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1})
 	stateListener := &StateChangeListenerMock{}
 	circuitbreaker.RegisterStateChangeListeners(stateListener)
 	if err != nil {
@@ -241,7 +241,7 @@ func TestCircuitBreakerSlotIntegration_Concurrency(t *testing.T) {
 		Threshold:        0.1,
 	}
 
-	_, err = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1, cbRule2})
+	_, err, _ = circuitbreaker.LoadRules([]*circuitbreaker.Rule{cbRule1, cbRule2})
 	stateListener := &StateChangeListenerMock{}
 	circuitbreaker.RegisterStateChangeListeners(stateListener)
 	if err != nil {

--- a/tests/maxsize_rule_list_benchmark_test.go
+++ b/tests/maxsize_rule_list_benchmark_test.go
@@ -28,7 +28,7 @@ func Test_Size_1000_Circuit_Breaker_Rules_Update(t *testing.T) {
 		})
 	}
 
-	_, err := cb.LoadRules(rs)
+	_, err, _ := cb.LoadRules(rs)
 	if err != nil {
 		t.Errorf("error")
 	}
@@ -56,7 +56,7 @@ func Benchmark_Size_1000_Circuit_Breaker_Rules_Update(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := cb.LoadRules(rs)
+		_, err, _ := cb.LoadRules(rs)
 		if err != nil {
 			b.Errorf("error")
 		}
@@ -80,7 +80,7 @@ func Test_Size_10000_Circuit_Breaker_Rules_Update(t *testing.T) {
 		})
 	}
 
-	_, err := cb.LoadRules(rs)
+	_, err, _ := cb.LoadRules(rs)
 	if err != nil {
 		t.Errorf("error")
 	}
@@ -107,7 +107,7 @@ func Benchmark_Size_10000_Circuit_Breaker_Rules_Update(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := cb.LoadRules(rs)
+		_, err, _ := cb.LoadRules(rs)
 		if err != nil {
 			b.Errorf("error")
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
PR per issue #236 

### Does this pull request fix one issue?
Add fixes to solve issue #236 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add logic to check for existing rule changes in this API and return as the first value
Put recover method in one place so that all panics can be caught and assigned to the second value
Failed rules will be returned to caller as the third value
Add duplicate rule checker so that all loaded rules will be unique

### Describe how to verify it
Added more UT cases to verify it

### Special notes for reviews
Also Add CB Strategy Enumeration upper boundary. 
Modify API signature