### PR TITLE
Flow rule cache/check

### DIFF
--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -172,13 +172,14 @@ func onRuleUpdate(rules []*Rule) (err error) {
 }
 
 // LoadRules loads the given flow rules to the rule manager, while all previous rules will be replaced.
+// the first returned value indicates whether do real load operation, if the rules is the same with previous rules, return false
 func LoadRules(rules []*Rule) (bool, error) {
 	// TODO: rethink the design
 	tcMux.RLock()
 	isEqual := reflect.DeepEqual(currentRules, rules)
 	tcMux.RUnlock()
 	if isEqual {
-		logging.Info("[Flow] Load rules repetition, does not load")
+		logging.Info("[Flow] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
 	}
 

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -418,3 +418,27 @@ func Test_buildRulesOfRes(t *testing.T) {
 		assert.True(t, tcs[3].boundStat == stat4)
 	})
 }
+
+func TestLoadRules(t *testing.T) {
+	t.Run("loadSameRules", func(t *testing.T) {
+		_, err := LoadRules([]*Rule{
+			{
+				Resource:               "some-test",
+				Threshold:              10,
+				TokenCalculateStrategy: Direct,
+				ControlBehavior:        Reject,
+			},
+		})
+		assert.Nil(t, err)
+		ok, err := LoadRules([]*Rule{
+			{
+				Resource:               "some-test",
+				Threshold:              10,
+				TokenCalculateStrategy: Direct,
+				ControlBehavior:        Reject,
+			},
+		})
+		assert.Nil(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -50,8 +50,8 @@ func FlowRulesUpdater(data interface{}) error {
 			fmt.Sprintf("Fail to type assert data to []flow.Rule or []*flow.Rule, in fact, data: %+v", data),
 		)
 	}
-	succ, err := flow.LoadRules(rules)
-	if succ && err == nil {
+	_, err := flow.LoadRules(rules)
+	if err == nil {
 		return nil
 	}
 	return NewError(


### PR DESCRIPTION
Describe what this PR does / why we need it
In order to avoid the meaningless updates to the property, downstream of property manager should
cache last update value to check consistency.

Does this pull request fix one issue?
Fix:#111

Describe how you did it
Using reflect.deepequal,maybe we need to think about performance

Describe how to verify it
ut

Special notes for reviews