### PR TITLE
Make map&slice with init capacity to decrease grow cost

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,7 +98,7 @@ func WithSlotChain(chain *base.SlotChain) EntryOption {
 func WithAttachment(key interface{}, value interface{}) EntryOption {
 	return func(opts *EntryOptions) {
 		if opts.attachments == nil {
-			opts.attachments = make(map[interface{}]interface{})
+			opts.attachments = make(map[interface{}]interface{}, 8)
 		}
 		opts.attachments[key] = value
 	}
@@ -108,7 +108,7 @@ func WithAttachment(key interface{}, value interface{}) EntryOption {
 func WithAttachments(data map[interface{}]interface{}) EntryOption {
 	return func(opts *EntryOptions) {
 		if opts.attachments == nil {
-			opts.attachments = make(map[interface{}]interface{})
+			opts.attachments = make(map[interface{}]interface{}, len(data))
 		}
 		for key, value := range data {
 			opts.attachments[key] = value

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -364,7 +364,7 @@ func (s *slowRequestLeapArray) currentCounter() *slowRequestCounter {
 
 func (s *slowRequestLeapArray) allCounter() []*slowRequestCounter {
 	buckets := s.data.Values()
-	ret := make([]*slowRequestCounter, 0)
+	ret := make([]*slowRequestCounter, 0, len(buckets))
 	for _, b := range buckets {
 		mb := b.Value.Load()
 		if mb == nil {
@@ -541,7 +541,7 @@ func (s *errorCounterLeapArray) currentCounter() *errorCounter {
 
 func (s *errorCounterLeapArray) allCounter() []*errorCounter {
 	buckets := s.data.Values()
-	ret := make([]*errorCounter, 0)
+	ret := make([]*errorCounter, 0, len(buckets))
 	for _, b := range buckets {
 		mb := b.Value.Load()
 		if mb == nil {

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -14,7 +14,7 @@ import (
 type CircuitBreakerGenFunc func(r *Rule, reuseStat interface{}) (CircuitBreaker, error)
 
 var (
-	cbGenFuncMap = make(map[Strategy]CircuitBreakerGenFunc)
+	cbGenFuncMap = make(map[Strategy]CircuitBreakerGenFunc, 4)
 
 	breakerRules = make(map[string][]*Rule)
 	breakers     = make(map[string][]CircuitBreaker)
@@ -122,10 +122,10 @@ func LoadRules(rules []*Rule) (bool, error) {
 }
 
 func getBreakersOfResource(resource string) []CircuitBreaker {
-	ret := make([]CircuitBreaker, 0)
 	updateMux.RLock()
 	resCBs := breakers[resource]
 	updateMux.RUnlock()
+	ret := make([]CircuitBreaker, 0, len(resCBs))
 	if len(resCBs) == 0 {
 		return ret
 	}
@@ -181,7 +181,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		}
 	}()
 
-	newBreakerRules := make(map[string][]*Rule)
+	newBreakerRules := make(map[string][]*Rule, len(rules))
 	for _, rule := range rules {
 		if rule == nil {
 			continue
@@ -200,7 +200,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		newBreakerRules[classification] = ruleSet
 	}
 
-	newBreakers := make(map[string][]CircuitBreaker)
+	newBreakers := make(map[string][]CircuitBreaker, len(rules))
 	// in order to avoid growing, build newBreakers in advance
 	for res, rules := range newBreakerRules {
 		newBreakers[res] = make([]CircuitBreaker, 0, len(rules))
@@ -275,7 +275,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 }
 
 func rulesFrom(rm map[string][]*Rule) []*Rule {
-	rules := make([]*Rule, 0)
+	rules := make([]*Rule, 0, 8)
 	if len(rm) == 0 {
 		return rules
 	}

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -26,7 +26,7 @@ type trafficControllerGenKey struct {
 type TrafficControllerMap map[string][]*TrafficShapingController
 
 var (
-	tcGenFuncMap = make(map[trafficControllerGenKey]TrafficControllerGenFunc)
+	tcGenFuncMap = make(map[trafficControllerGenKey]TrafficControllerGenFunc, 4)
 	tcMap        = make(TrafficControllerMap)
 	tcMux        = new(sync.RWMutex)
 	nopStat      = &standaloneStatistic{
@@ -130,7 +130,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		}
 	}()
 
-	resRulesMap := make(map[string][]*Rule)
+	resRulesMap := make(map[string][]*Rule, len(rules))
 	for _, rule := range rules {
 		if err := IsValidRule(rule); err != nil {
 			logging.Warn("[Flow onRuleUpdate] Ignoring invalid flow rule", "rule", rule, "reason", err)
@@ -230,7 +230,7 @@ func ClearRules() error {
 }
 
 func rulesFrom(m TrafficControllerMap) []*Rule {
-	rules := make([]*Rule, 0)
+	rules := make([]*Rule, 0, 8)
 	if len(m) == 0 {
 		return rules
 	}

--- a/core/hotspot/cache/lru.go
+++ b/core/hotspot/cache/lru.go
@@ -31,7 +31,7 @@ func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
 	c := &LRU{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[interface{}]*list.Element),
+		items:     make(map[interface{}]*list.Element, 64),
 		onEvict:   onEvict,
 	}
 	return c, nil

--- a/core/hotspot/rule_manager.go
+++ b/core/hotspot/rule_manager.go
@@ -17,7 +17,7 @@ type TrafficControllerGenFunc func(r *Rule, reuseMetric *ParamsMetric) TrafficSh
 type trafficControllerMap map[string][]TrafficShapingController
 
 var (
-	tcGenFuncMap = make(map[ControlBehavior]TrafficControllerGenFunc)
+	tcGenFuncMap = make(map[ControlBehavior]TrafficControllerGenFunc, 4)
 	tcMap        = make(trafficControllerMap)
 	tcMux        = new(sync.RWMutex)
 )
@@ -117,7 +117,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		}
 	}()
 
-	newRuleMap := make(map[string][]*Rule)
+	newRuleMap := make(map[string][]*Rule, len(rules))
 	for _, r := range rules {
 		if err := IsValidRule(r); err != nil {
 			logging.Warn("[HotSpot onRuleUpdate] Ignoring invalid hotspot rule when loading new rules", "rule", r, "err", err)
@@ -213,7 +213,7 @@ func logRuleUpdate(m trafficControllerMap) {
 }
 
 func rulesFrom(m trafficControllerMap) []*Rule {
-	rules := make([]*Rule, 0)
+	rules := make([]*Rule, 0, 8)
 	if len(m) == 0 {
 		return rules
 	}

--- a/core/isolation/rule_manager.go
+++ b/core/isolation/rule_manager.go
@@ -19,7 +19,7 @@ func LoadRules(rules []*Rule) (updated bool, err error) {
 	updated = true
 	err = nil
 
-	m := make(map[string][]*Rule)
+	m := make(map[string][]*Rule, len(rules))
 	for _, r := range rules {
 		if e := IsValid(r); e != nil {
 			logging.Error(e, "Invalid isolation rule in isolation.LoadRules()", "rule", r)
@@ -105,7 +105,7 @@ func getRulesOfResource(res string) []*Rule {
 }
 
 func rulesFrom(m map[string][]*Rule) []*Rule {
-	rules := make([]*Rule, 0)
+	rules := make([]*Rule, 0, 8)
 	if len(m) == 0 {
 		return rules
 	}

--- a/core/log/metric/aggregator.go
+++ b/core/log/metric/aggregator.go
@@ -131,7 +131,7 @@ func isItemTimestampInTime(ts uint64, currentSecStart uint64) bool {
 }
 
 func currentMetricItems(retriever base.MetricItemRetriever, currentTime uint64) map[uint64]*base.MetricItem {
-	m := make(map[uint64]*base.MetricItem, 2)
+	m := make(map[uint64]*base.MetricItem, 8)
 	items := retriever.MetricsOnCondition(func(ts uint64) bool {
 		return isItemTimestampInTime(ts, currentTime)
 	})

--- a/core/log/metric/aggregator.go
+++ b/core/log/metric/aggregator.go
@@ -131,10 +131,10 @@ func isItemTimestampInTime(ts uint64, currentSecStart uint64) bool {
 }
 
 func currentMetricItems(retriever base.MetricItemRetriever, currentTime uint64) map[uint64]*base.MetricItem {
-	m := make(map[uint64]*base.MetricItem, 8)
 	items := retriever.MetricsOnCondition(func(ts uint64) bool {
 		return isItemTimestampInTime(ts, currentTime)
 	})
+	m := make(map[uint64]*base.MetricItem, len(items))
 	for _, item := range items {
 		if !isActiveMetricItem(item) {
 			continue

--- a/core/log/metric/common.go
+++ b/core/log/metric/common.go
@@ -73,7 +73,7 @@ func listMetricFilesConditional(baseDir string, filePattern string, predicate fu
 	if err != nil {
 		return nil, err
 	}
-	arr := make([]string, 0, 8)
+	arr := make([]string, 0, len(dir))
 	for _, f := range dir {
 		if f.IsDir() {
 			continue

--- a/core/log/metric/common.go
+++ b/core/log/metric/common.go
@@ -73,7 +73,7 @@ func listMetricFilesConditional(baseDir string, filePattern string, predicate fu
 	if err != nil {
 		return nil, err
 	}
-	arr := make([]string, 0)
+	arr := make([]string, 0, 8)
 	for _, f := range dir {
 		if f.IsDir() {
 			continue

--- a/core/log/metric/reader.go
+++ b/core/log/metric/reader.go
@@ -94,7 +94,7 @@ func (r *defaultMetricLogReader) readMetricsInOneFile(filename string, offset ui
 	defer file.Close()
 
 	bufReader := bufio.NewReaderSize(file, 8192)
-	items := make([]*base.MetricItem, 0)
+	items := make([]*base.MetricItem, 0, 8)
 	for {
 		line, err := readLine(bufReader)
 		if err != nil {
@@ -129,7 +129,7 @@ func (r *defaultMetricLogReader) readMetricsInOneFileByEndTime(filename string, 
 	defer file.Close()
 
 	bufReader := bufio.NewReaderSize(file, 8192)
-	items := make([]*base.MetricItem, 0)
+	items := make([]*base.MetricItem, 0, 8)
 	for {
 		line, err := readLine(bufReader)
 		if err != nil {
@@ -161,7 +161,7 @@ func (r *defaultMetricLogReader) readMetricsInOneFileByEndTime(filename string, 
 }
 
 func readLine(bufReader *bufio.Reader) (string, error) {
-	buf := make([]byte, 0)
+	buf := make([]byte, 0, 64)
 	for {
 		line, ne, err := bufReader.ReadLine()
 		if err != nil {

--- a/core/log/metric/reader.go
+++ b/core/log/metric/reader.go
@@ -94,7 +94,7 @@ func (r *defaultMetricLogReader) readMetricsInOneFile(filename string, offset ui
 	defer file.Close()
 
 	bufReader := bufio.NewReaderSize(file, 8192)
-	items := make([]*base.MetricItem, 0, 8)
+	items := make([]*base.MetricItem, 0, 1024)
 	for {
 		line, err := readLine(bufReader)
 		if err != nil {
@@ -129,7 +129,7 @@ func (r *defaultMetricLogReader) readMetricsInOneFileByEndTime(filename string, 
 	defer file.Close()
 
 	bufReader := bufio.NewReaderSize(file, 8192)
-	items := make([]*base.MetricItem, 0, 8)
+	items := make([]*base.MetricItem, 0, 1024)
 	for {
 		line, err := readLine(bufReader)
 		if err != nil {

--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -220,7 +220,7 @@ func (la *LeapArray) valuesWithTime(now uint64) []*BucketWrap {
 	if now <= 0 {
 		return make([]*BucketWrap, 0)
 	}
-	ret := make([]*BucketWrap, 0, 8)
+	ret := make([]*BucketWrap, 0, la.array.length)
 	for i := 0; i < la.array.length; i++ {
 		ww := la.array.get(i)
 		if ww == nil || la.isBucketDeprecated(now, ww) {
@@ -235,7 +235,7 @@ func (la *LeapArray) ValuesConditional(now uint64, predicate base.TimePredicate)
 	if now <= 0 {
 		return make([]*BucketWrap, 0)
 	}
-	ret := make([]*BucketWrap, 0, 8)
+	ret := make([]*BucketWrap, 0, la.array.length)
 	for i := 0; i < la.array.length; i++ {
 		ww := la.array.get(i)
 		if ww == nil || la.isBucketDeprecated(now, ww) || !predicate(atomic.LoadUint64(&ww.BucketStart)) {

--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -220,7 +220,7 @@ func (la *LeapArray) valuesWithTime(now uint64) []*BucketWrap {
 	if now <= 0 {
 		return make([]*BucketWrap, 0)
 	}
-	ret := make([]*BucketWrap, 0)
+	ret := make([]*BucketWrap, 0, 8)
 	for i := 0; i < la.array.length; i++ {
 		ww := la.array.get(i)
 		if ww == nil || la.isBucketDeprecated(now, ww) {
@@ -235,7 +235,7 @@ func (la *LeapArray) ValuesConditional(now uint64, predicate base.TimePredicate)
 	if now <= 0 {
 		return make([]*BucketWrap, 0)
 	}
-	ret := make([]*BucketWrap, 0)
+	ret := make([]*BucketWrap, 0, 8)
 	for i := 0; i < la.array.length; i++ {
 		ww := la.array.get(i)
 		if ww == nil || la.isBucketDeprecated(now, ww) || !predicate(atomic.LoadUint64(&ww.BucketStart)) {

--- a/core/stat/base/sliding_window_metric.go
+++ b/core/stat/base/sliding_window_metric.go
@@ -158,7 +158,7 @@ func (m *SlidingWindowMetric) SecondMetricsOnCondition(predicate base.TimePredic
 	ws := m.real.ValuesConditional(util.CurrentTimeMillis(), predicate)
 
 	// Aggregate second-level MetricItem (only for stable metrics)
-	wm := make(map[uint64][]*BucketWrap)
+	wm := make(map[uint64][]*BucketWrap, 8)
 	for _, w := range ws {
 		bucketStart := atomic.LoadUint64(&w.BucketStart)
 		secStart := bucketStart - bucketStart%1000
@@ -168,7 +168,7 @@ func (m *SlidingWindowMetric) SecondMetricsOnCondition(predicate base.TimePredic
 			wm[secStart] = []*BucketWrap{w}
 		}
 	}
-	items := make([]*base.MetricItem, 0)
+	items := make([]*base.MetricItem, 0, 8)
 	for ts, values := range wm {
 		if len(values) == 0 {
 			continue

--- a/core/system/rule_manager.go
+++ b/core/system/rule_manager.go
@@ -42,7 +42,7 @@ func getRules() []*Rule {
 	ruleMapMux.RLock()
 	defer ruleMapMux.RUnlock()
 
-	rules := make([]*Rule, 0)
+	rules := make([]*Rule, 0, 8)
 	for _, rs := range ruleMap {
 		rules = append(rules, rs...)
 	}

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -23,7 +23,7 @@ func FlowRuleJsonArrayParser(src []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	rules := make([]*flow.Rule, 0)
+	rules := make([]*flow.Rule, 0, 8)
 	if err := json.Unmarshal(src, &rules); err != nil {
 		desc := fmt.Sprintf("Fail to convert source bytes to []*flow.Rule, err: %s", err.Error())
 		return nil, NewError(ConvertSourceError, desc)
@@ -37,7 +37,7 @@ func FlowRulesUpdater(data interface{}) error {
 		return flow.ClearRules()
 	}
 
-	rules := make([]*flow.Rule, 0)
+	rules := make([]*flow.Rule, 0, 8)
 	if val, ok := data.([]flow.Rule); ok {
 		for _, v := range val {
 			rules = append(rules, &v)
@@ -70,7 +70,7 @@ func SystemRuleJsonArrayParser(src []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	rules := make([]*system.Rule, 0)
+	rules := make([]*system.Rule, 0, 8)
 	if err := json.Unmarshal(src, &rules); err != nil {
 		desc := fmt.Sprintf("Fail to convert source bytes to []*system.Rule, err: %s", err.Error())
 		return nil, NewError(ConvertSourceError, desc)
@@ -84,7 +84,7 @@ func SystemRulesUpdater(data interface{}) error {
 		return system.ClearRules()
 	}
 
-	rules := make([]*system.Rule, 0)
+	rules := make([]*system.Rule, 0, 8)
 	if val, ok := data.([]system.Rule); ok {
 		for _, v := range val {
 			rules = append(rules, &v)
@@ -116,7 +116,7 @@ func CircuitBreakerRuleJsonArrayParser(src []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	rules := make([]*cb.Rule, 0)
+	rules := make([]*cb.Rule, 0, 8)
 	if err := json.Unmarshal(src, &rules); err != nil {
 		desc := fmt.Sprintf("Fail to convert source bytes to []*circuitbreaker.Rule, err: %s", err.Error())
 		return nil, NewError(ConvertSourceError, desc)
@@ -159,7 +159,7 @@ func HotSpotParamRuleJsonArrayParser(src []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	hotspotRules := make([]*HotspotRule, 0)
+	hotspotRules := make([]*HotspotRule, 0, 8)
 	if err := json.Unmarshal(src, &hotspotRules); err != nil {
 		desc := fmt.Sprintf("Fail to convert source bytes to []*hotspot.Rule, err: %s", err.Error())
 		return nil, NewError(ConvertSourceError, desc)
@@ -189,7 +189,7 @@ func HotSpotParamRulesUpdater(data interface{}) error {
 		return hotspot.ClearRules()
 	}
 
-	rules := make([]*hotspot.Rule, 0)
+	rules := make([]*hotspot.Rule, 0, 8)
 	if val, ok := data.([]hotspot.Rule); ok {
 		for _, v := range val {
 			rules = append(rules, &v)

--- a/ext/datasource/hotspot_rule_converter.go
+++ b/ext/datasource/hotspot_rule_converter.go
@@ -81,7 +81,7 @@ func (s *SpecificValue) String() string {
 
 // arseSpecificItems parses the SpecificValue as real value.
 func parseSpecificItems(source []SpecificValue) map[interface{}]int64 {
-	ret := make(map[interface{}]int64)
+	ret := make(map[interface{}]int64, len(source))
 	if len(source) == 0 {
 		return ret
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Make map&slice with init capacity to decrease grow cost.

I have done a simple benchmark of map.  
Benchmark code:
```go
func BenchmarkMap(b *testing.B) {
	for len := 16; len <= 2048; len *= 2 {
		nohint := fmt.Sprintf("map-len-%d-nohint", len)
		b.Run(nohint, func(b *testing.B) {
			keys := stringutil.RandomStrings(10, len)
			for i := 0; i < b.N; i++ {
				m := make(map[string]struct{})
				for _, k := range keys {
					m[k] = struct{}{}
				}
			}
		})

		hint := fmt.Sprintf("map-len-%d-hint", len)
		b.Run(hint, func(b *testing.B) {
			keys := stringutil.RandomStrings(10, len)
			for i := 0; i < b.N; i++ {
				m := make(map[string]struct{}, len)
				for _, k := range keys {
					m[k] = struct{}{}
				}
			}
		})
	}
}
```
Benchmark result:
```
goos: darwin
goarch: amd64
pkg: test
BenchmarkMap/map-len-16-nohint-4                 1024162              1207 ns/op
BenchmarkMap/map-len-16-hint-4                   1979204               612 ns/op
BenchmarkMap/map-len-32-nohint-4                  342871              2920 ns/op
BenchmarkMap/map-len-32-hint-4                    916936              1317 ns/op
BenchmarkMap/map-len-64-nohint-4                  193783              6034 ns/op
BenchmarkMap/map-len-64-hint-4                    428074              2498 ns/op
BenchmarkMap/map-len-128-nohint-4                  99069             11546 ns/op
BenchmarkMap/map-len-128-hint-4                   218790              4932 ns/op
BenchmarkMap/map-len-256-nohint-4                  50898             23931 ns/op
BenchmarkMap/map-len-256-hint-4                   102020             10222 ns/op
BenchmarkMap/map-len-512-nohint-4                  22950             48523 ns/op
BenchmarkMap/map-len-512-hint-4                    57325             19982 ns/op
BenchmarkMap/map-len-1024-nohint-4                 12745             92749 ns/op
BenchmarkMap/map-len-1024-hint-4                   30240             38384 ns/op
BenchmarkMap/map-len-2048-nohint-4                  6195            189864 ns/op
BenchmarkMap/map-len-2048-hint-4                   14448             77945 ns/op
PASS
ok      test    23.131s
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews