### PR TITLE
Refine string builder usage in logging pkg

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -27,6 +27,8 @@ const (
 	// RecordLogFileName represents the default file name of the record log.
 	RecordLogFileName = "sentinel-record.log"
 	GlobalCallerDepth = 4
+
+	defaultLogMsgBufferSize = 256
 )
 
 var (
@@ -117,6 +119,8 @@ func caller(depth int) (file string, line int) {
 
 func AssembleMsg(depth int, logLevel, msg string, err error, keysAndValues ...interface{}) string {
 	sb := strings.Builder{}
+	sb.Grow(defaultLogMsgBufferSize)
+
 	file, line := caller(depth)
 	timeStr := time.Now().Format("2006-01-02 15:04:05.520")
 	caller := fmt.Sprintf("%s:%d", file, line)

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -109,3 +109,10 @@ func Benchmark_LoggingDebug_With_Precheck(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkAssembleMsg(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		AssembleMsg(1, "INFO", "test msg", nil, "k1", "v1", "k2", "v2")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Use string builder grow to reduce memory allocations in logging pkg.

Benchmark result:
```
goos: darwin
goarch: amd64
pkg: github.com/alibaba/sentinel-golang/logging
BenchmarkAssembleMsg/assemble_msg_using_string_builder_with_grow-4                742695              1681 ns/op             624 B/op          8 allocs/op
BenchmarkAssembleMsg/assemble_msg_using_string_builder_without_grow-4             678778              1901 ns/op             728 B/op         12 allocs/op
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews