### PR TITLE
Enhance config API, support initialization by config parser

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -27,10 +27,7 @@ func InitConfigWithYaml(filePath string) (err error) {
 	if err = applyYamlConfigFile(filePath); err != nil {
 		return err
 	}
-	if err = OverrideConfigFromEnvAndInitLog(); err != nil {
-		return err
-	}
-	return nil
+	return OverrideConfigFromEnvAndInitLog()
 }
 
 // applyYamlConfigFile loads general configuration from the given YAML file.

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -33,8 +33,8 @@ func TestLoadFromYamlFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := loadFromYamlFile(tt.args.filePath); (err != nil) != tt.wantErr {
-				t.Errorf("loadFromYamlFile() error = %v, wantErr %v", err, tt.wantErr)
+			if err := loadGlobalConfigFromYamlFile(tt.args.filePath); (err != nil) != tt.wantErr {
+				t.Errorf("loadGlobalConfigFromYamlFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -50,7 +50,7 @@ func TestOverrideFromSystemEnv(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	err := loadFromYamlFile(testDataBaseDir + "sentinel.yml")
+	err := loadGlobalConfigFromYamlFile(testDataBaseDir + "sentinel.yml")
 	if err != nil {
 		t.Errorf("Fail to initialize data.")
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. Refine config logic
2. Add `func InitWithParser(configBytes []byte, parser func([]byte) (*config.Entity, error)) (err error) ` to initialize Sentinel

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews