### PR TITLE
Fix bug that StatIntervalInMs do not take effect in throttling checker

### DIFF
--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -355,13 +355,13 @@ func getTrafficControllerListFor(name string) []*TrafficShapingController {
 	return tcMap[name]
 }
 
-func calculateReuseIndexFor(r *Rule, oldResCbs []*TrafficShapingController) (equalIdx, reuseStatIdx int) {
-	// the index of equivalent rule in old circuit breaker slice
+func calculateReuseIndexFor(r *Rule, oldResTcs []*TrafficShapingController) (equalIdx, reuseStatIdx int) {
+	// the index of equivalent rule in old traffic shaping controller slice
 	equalIdx = -1
-	// the index of statistic reusable rule in old circuit breaker slice
+	// the index of statistic reusable rule in old traffic shaping controller slice
 	reuseStatIdx = -1
 
-	for idx, oldTc := range oldResCbs {
+	for idx, oldTc := range oldResTcs {
 		oldRule := oldTc.BoundRule()
 		if oldRule.isEqualsTo(r) {
 			// break if there is equivalent rule
@@ -399,10 +399,10 @@ func buildRulesOfRes(res string, rulesOfRes []*Rule) []*TrafficShapingController
 
 		// First check equals scenario
 		if equalIdx >= 0 {
-			// reuse the old cb
+			// reuse the old tc
 			equalOldTc := oldResTcs[equalIdx]
 			newTcsOfRes = append(newTcsOfRes, equalOldTc)
-			// remove old cb from oldResCbs
+			// remove old tc from oldResTcs
 			tcMap[res] = append(oldResTcs[:equalIdx], oldResTcs[equalIdx+1:]...)
 			continue
 		}
@@ -428,7 +428,7 @@ func buildRulesOfRes(res string, rulesOfRes []*Rule) []*TrafficShapingController
 			continue
 		}
 		if reuseStatIdx >= 0 {
-			// remove old cb from oldResCbs
+			// remove old tc from oldResTcs
 			tcMap[res] = append(oldResTcs[:reuseStatIdx], oldResTcs[reuseStatIdx+1:]...)
 		}
 		newTcsOfRes = append(newTcsOfRes, tc)

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -442,33 +442,36 @@ func IsValidRule(rule *Rule) error {
 		return errors.New("nil Rule")
 	}
 	if rule.Resource == "" {
-		return errors.New("empty resource name")
+		return errors.New("empty Resource")
 	}
 	if rule.Threshold < 0 {
-		return errors.New("negative threshold")
+		return errors.New("negative Threshold")
 	}
 	if int32(rule.TokenCalculateStrategy) < 0 {
-		return errors.New("invalid token calculate strategy")
+		return errors.New("negative TokenCalculateStrategy")
 	}
 	if int32(rule.ControlBehavior) < 0 {
-		return errors.New("invalid control behavior")
+		return errors.New("negative ControlBehavior")
 	}
 	if !(rule.RelationStrategy >= CurrentResource && rule.RelationStrategy <= AssociatedResource) {
-		return errors.New("invalid relation strategy")
+		return errors.New("invalid RelationStrategy")
 	}
 	if rule.RelationStrategy == AssociatedResource && rule.RefResource == "" {
-		return errors.New("Bad flow rule: invalid relation strategy")
+		return errors.New("RefResource must be non empty when RelationStrategy is AssociatedResource")
 	}
 	if rule.TokenCalculateStrategy == WarmUp {
 		if rule.WarmUpPeriodSec <= 0 {
-			return errors.New("invalid WarmUpPeriodSec")
+			return errors.New("WarmUpPeriodSec must be great than 0")
 		}
 		if rule.WarmUpColdFactor == 1 {
 			return errors.New("WarmUpColdFactor must be great than 1")
 		}
 	}
 	if rule.ControlBehavior == Throttling && rule.MaxQueueingTimeMs == 0 {
-		return errors.New("invalid MaxQueueingTimeMs")
+		return errors.New("MaxQueueingTimeMs can't be 0 when control behavior is Throttling")
+	}
+	if rule.ControlBehavior == Throttling && rule.StatIntervalInMs <= 0 {
+		return errors.New("StatIntervalInMs must be great than 0 when control behavior is Throttling")
 	}
 	if rule.StatIntervalInMs > config.GlobalStatisticIntervalMsTotal()*60 {
 		return errors.New("StatIntervalInMs must be less than 10 minutes")

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -470,8 +470,8 @@ func IsValidRule(rule *Rule) error {
 	if rule.ControlBehavior == Throttling && rule.MaxQueueingTimeMs == 0 {
 		return errors.New("MaxQueueingTimeMs can't be 0 when control behavior is Throttling")
 	}
-	if rule.StatIntervalInMs > config.GlobalStatisticIntervalMsTotal()*60 {
-		return errors.New("StatIntervalInMs must be less than 10 minutes")
+	if rule.StatIntervalInMs > 10*60*1000 {
+		logging.Info("StatIntervalInMs is great than 10 minutes, less than 10 minutes is recommended.")
 	}
 	return nil
 }

--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -68,7 +68,7 @@ func init() {
 			return nil, err
 		}
 		tsc.flowCalculator = NewDirectTrafficShapingCalculator(tsc, rule.Threshold)
-		tsc.flowChecker = NewThrottlingChecker(tsc, rule.MaxQueueingTimeMs)
+		tsc.flowChecker = NewThrottlingChecker(tsc, rule.MaxQueueingTimeMs, rule.StatIntervalInMs)
 		return tsc, nil
 	}
 	tcGenFuncMap[trafficControllerGenKey{
@@ -106,7 +106,7 @@ func init() {
 			return nil, err
 		}
 		tsc.flowCalculator = NewWarmUpTrafficShapingCalculator(tsc, rule)
-		tsc.flowChecker = NewThrottlingChecker(tsc, rule.MaxQueueingTimeMs)
+		tsc.flowChecker = NewThrottlingChecker(tsc, rule.MaxQueueingTimeMs, rule.StatIntervalInMs)
 		return tsc, nil
 	}
 }
@@ -469,9 +469,6 @@ func IsValidRule(rule *Rule) error {
 	}
 	if rule.ControlBehavior == Throttling && rule.MaxQueueingTimeMs == 0 {
 		return errors.New("MaxQueueingTimeMs can't be 0 when control behavior is Throttling")
-	}
-	if rule.ControlBehavior == Throttling && rule.StatIntervalInMs <= 0 {
-		return errors.New("StatIntervalInMs must be great than 0 when control behavior is Throttling")
 	}
 	if rule.StatIntervalInMs > config.GlobalStatisticIntervalMsTotal()*60 {
 		return errors.New("StatIntervalInMs must be less than 10 minutes")

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -54,14 +54,16 @@ func TestIsValidFlowRule(t *testing.T) {
 	badRule1 := &Rule{Threshold: 1, Resource: ""}
 	badRule2 := &Rule{Threshold: -1.9, Resource: "test"}
 	badRule3 := &Rule{Threshold: 5, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Reject}
-	goodRule1 := &Rule{Threshold: 10, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Throttling, WarmUpPeriodSec: 10, MaxQueueingTimeMs: 10}
+	goodRule1 := &Rule{Threshold: 10, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Throttling, WarmUpPeriodSec: 10, MaxQueueingTimeMs: 10, StatIntervalInMs: 1000}
 	badRule4 := &Rule{Threshold: 5, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Reject, StatIntervalInMs: 6000000}
+	badRule5 := &Rule{Threshold: 10, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Throttling, WarmUpPeriodSec: 10, MaxQueueingTimeMs: 10}
 
 	assert.Error(t, IsValidRule(badRule1))
 	assert.Error(t, IsValidRule(badRule2))
 	assert.Error(t, IsValidRule(badRule3))
 	assert.NoError(t, IsValidRule(goodRule1))
 	assert.Error(t, IsValidRule(badRule4))
+	assert.Error(t, IsValidRule(badRule5))
 }
 
 func TestGetRules(t *testing.T) {
@@ -88,6 +90,7 @@ func TestGetRules(t *testing.T) {
 			RefResource:            "",
 			WarmUpPeriodSec:        0,
 			MaxQueueingTimeMs:      10,
+			StatIntervalInMs:       1000,
 		}
 		if _, err := LoadRules([]*Rule{r1, r2}); err != nil {
 			t.Fatal(err)
@@ -130,6 +133,7 @@ func TestGetRules(t *testing.T) {
 			RefResource:            "",
 			WarmUpPeriodSec:        0,
 			MaxQueueingTimeMs:      10,
+			StatIntervalInMs:       1000,
 		}
 		if _, err := LoadRules([]*Rule{r1, r2}); err != nil {
 			t.Fatal(err)

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -56,14 +56,12 @@ func TestIsValidFlowRule(t *testing.T) {
 	badRule3 := &Rule{Threshold: 5, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Reject}
 	goodRule1 := &Rule{Threshold: 10, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Throttling, WarmUpPeriodSec: 10, MaxQueueingTimeMs: 10, StatIntervalInMs: 1000}
 	badRule4 := &Rule{Threshold: 5, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Reject, StatIntervalInMs: 6000000}
-	badRule5 := &Rule{Threshold: 10, Resource: "test", TokenCalculateStrategy: WarmUp, ControlBehavior: Throttling, WarmUpPeriodSec: 10, MaxQueueingTimeMs: 10}
 
 	assert.Error(t, IsValidRule(badRule1))
 	assert.Error(t, IsValidRule(badRule2))
 	assert.Error(t, IsValidRule(badRule3))
 	assert.NoError(t, IsValidRule(goodRule1))
 	assert.Error(t, IsValidRule(badRule4))
-	assert.Error(t, IsValidRule(badRule5))
 }
 
 func TestGetRules(t *testing.T) {

--- a/core/flow/tc_throttling_test.go
+++ b/core/flow/tc_throttling_test.go
@@ -10,48 +10,88 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newTestThrottlingChecker(intervalMs uint32, threshold float64, timeoutMs uint32) (*ThrottlingChecker, error) {
+	rule := &Rule{
+		Resource:               "test",
+		TokenCalculateStrategy: Direct,
+		ControlBehavior:        Throttling,
+		Threshold:              threshold,
+		StatIntervalInMs:       intervalMs,
+		MaxQueueingTimeMs:      timeoutMs,
+	}
+
+	boundStat, err := generateStatFor(rule)
+	if err != nil {
+		return nil, err
+	}
+
+	tsc, err := NewTrafficShapingController(rule, boundStat)
+	if err != nil || tsc == nil {
+		return nil, err
+	}
+
+	return NewThrottlingChecker(tsc, timeoutMs), nil
+}
+
 func TestThrottlingChecker_DoCheckNoQueueingSingleThread(t *testing.T) {
-	tc := NewThrottlingChecker(nil, 0)
-	var qps float64 = 5.0
+	intervalMs := 10000
+	threshold := 50.0
+	timeoutMs := 0
+
+	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
+	assert.True(t, err == nil, err)
 
 	// The first request will pass.
-	ret := tc.DoCheck(nil, 1, qps)
+	ret := tc.DoCheck(nil, 1, threshold)
 	assert.True(t, ret == nil || ret.IsPass())
 
-	for i := 0; i < int(qps); i++ {
-		assert.True(t, tc.DoCheck(nil, 1, qps).IsBlocked())
+	reqCount := 10
+	for i := 0; i < reqCount; i++ {
+		assert.True(t, tc.DoCheck(nil, 1, threshold).IsBlocked())
 	}
-	time.Sleep(time.Duration(1000/int(qps)+10) * time.Millisecond)
+	time.Sleep(time.Duration(intervalMs/int(threshold)*reqCount+10) * time.Millisecond)
 
-	assert.True(t, tc.DoCheck(nil, 1, qps) == nil)
-	assert.True(t, tc.DoCheck(nil, 1, qps).IsBlocked())
+	assert.True(t, tc.DoCheck(nil, 1, threshold) == nil)
+	assert.True(t, tc.DoCheck(nil, 1, threshold).IsBlocked())
 }
 
 func TestThrottlingChecker_DoCheckSingleThread(t *testing.T) {
-	tc := NewThrottlingChecker(nil, 1000)
-	var qps float64 = 5.0
+	intervalMs := 10000
+	threshold := 50.0
+	timeoutMs := 2000
+
+	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
+	assert.True(t, err == nil, err)
+
 	resultList := make([]*base.TokenResult, 0)
-	for i := 0; i < 10; i++ {
-		res := tc.DoCheck(nil, 1, qps)
+	reqCount := 20
+	for i := 0; i < reqCount; i++ {
+		res := tc.DoCheck(nil, 1, threshold)
 		resultList = append(resultList, res)
 	}
 	assert.True(t, resultList[0] == nil)
 
-	for i := 1; i <= int(qps); i++ {
+	// waitCount is count of request that will wait and not be blocked
+	waitCount := int(float64(timeoutMs) / (float64(intervalMs) / threshold))
+	for i := 1; i <= waitCount; i++ {
 		assert.True(t, resultList[i].Status() == base.ResultStatusShouldWait)
 		wt := resultList[i].WaitMs()
-		assert.InEpsilon(t, i*1000/int(qps), wt, 10)
+		assert.InEpsilon(t, i*1000/int(waitCount), wt, 10)
 	}
-	for i := int(qps) + 1; i < 10; i++ {
+	for i := waitCount + 1; i < reqCount; i++ {
 		assert.True(t, resultList[i].IsBlocked())
 	}
 }
 
 func TestThrottlingChecker_DoCheckQueueingParallel(t *testing.T) {
-	tc := NewThrottlingChecker(nil, 1000)
-	var qps float64 = 5.0
+	intervalMs := 10000
+	threshold := 50.0
+	timeoutMs := 0
 
-	assert.True(t, tc.DoCheck(nil, 1, qps) == nil)
+	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
+	assert.True(t, err == nil, err)
+
+	assert.True(t, tc.DoCheck(nil, 1, threshold) == nil)
 
 	wg := &sync.WaitGroup{}
 	gc := 24
@@ -60,7 +100,7 @@ func TestThrottlingChecker_DoCheckQueueingParallel(t *testing.T) {
 	var waitCount, blockCount int32 = 0, 0
 	for i := 0; i < gc; i++ {
 		go func() {
-			res := tc.DoCheck(nil, 1, qps)
+			res := tc.DoCheck(nil, 1, threshold)
 			if res.IsBlocked() {
 				atomic.AddInt32(&blockCount, 1)
 			}
@@ -73,5 +113,5 @@ func TestThrottlingChecker_DoCheckQueueingParallel(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, int32(gc), waitCount+blockCount)
 	// Non-strict mode may not be strictly accurate, so here we tolerate a delta.
-	assert.InEpsilon(t, qps, waitCount, 1)
+	assert.InEpsilon(t, threshold/(float64(intervalMs)/1000.0), waitCount, 1)
 }

--- a/core/flow/tc_throttling_test.go
+++ b/core/flow/tc_throttling_test.go
@@ -10,36 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestThrottlingChecker(intervalMs uint32, threshold float64, timeoutMs uint32) (*ThrottlingChecker, error) {
-	rule := &Rule{
-		Resource:               "test",
-		TokenCalculateStrategy: Direct,
-		ControlBehavior:        Throttling,
-		Threshold:              threshold,
-		StatIntervalInMs:       intervalMs,
-		MaxQueueingTimeMs:      timeoutMs,
-	}
-
-	boundStat, err := generateStatFor(rule)
-	if err != nil {
-		return nil, err
-	}
-
-	tsc, err := NewTrafficShapingController(rule, boundStat)
-	if err != nil || tsc == nil {
-		return nil, err
-	}
-
-	return NewThrottlingChecker(tsc, timeoutMs), nil
-}
-
 func TestThrottlingChecker_DoCheckNoQueueingSingleThread(t *testing.T) {
 	intervalMs := 10000
 	threshold := 50.0
 	timeoutMs := 0
 
-	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
-	assert.True(t, err == nil, err)
+	tc := NewThrottlingChecker(nil, uint32(timeoutMs), uint32(intervalMs))
 
 	// The first request will pass.
 	ret := tc.DoCheck(nil, 1, threshold)
@@ -60,8 +36,7 @@ func TestThrottlingChecker_DoCheckSingleThread(t *testing.T) {
 	threshold := 50.0
 	timeoutMs := 2000
 
-	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
-	assert.True(t, err == nil, err)
+	tc := NewThrottlingChecker(nil, uint32(timeoutMs), uint32(intervalMs))
 
 	resultList := make([]*base.TokenResult, 0)
 	reqCount := 20
@@ -88,8 +63,7 @@ func TestThrottlingChecker_DoCheckQueueingParallel(t *testing.T) {
 	threshold := 50.0
 	timeoutMs := 0
 
-	tc, err := newTestThrottlingChecker(uint32(intervalMs), threshold, uint32(timeoutMs))
-	assert.True(t, err == nil, err)
+	tc := NewThrottlingChecker(nil, uint32(timeoutMs), uint32(intervalMs))
 
 	assert.True(t, tc.DoCheck(nil, 1, threshold) == nil)
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fix bug that StatIntervalInMs do not take effect in throttling checker.

As the doc [流量控制](https://github.com/alibaba/sentinel-golang/wiki/%E6%B5%81%E9%87%8F%E6%8E%A7%E5%88%B6) describes:

> 这里特别强调一下StatIntervalInMs和Threshold这两个字段，这两个字段决定了流量控制器的灵敏度。以 Direct + Reject 的流控策略为例，流量控制器的行为就是在StatIntervalInMs周期内，允许的最大请求数量是Threshold。比如，如果StatIntervalInMs是10000，Threshold是10000，那么流量控制器的行为就是10s内运行最多10000次访问。


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
By unit test and example.


### Special notes for reviews