### PR TITLE
Add flow benchmark test

### DIFF
--- a/tests/benchmark/flow/flow_benchmark_test.go
+++ b/tests/benchmark/flow/flow_benchmark_test.go
@@ -1,0 +1,139 @@
+package flow
+
+import (
+	"log"
+	"math"
+	"testing"
+
+	"github.com/alibaba/sentinel-golang/api"
+	"github.com/alibaba/sentinel-golang/core/flow"
+)
+
+func doCheck() {
+	if se, err := api.Entry("abc"); err == nil {
+		se.Exit()
+	} else {
+		log.Fatalf("Block err: %s", err.Error())
+	}
+}
+
+func loadDirectRejectRule() {
+	rule := &flow.Rule{
+		Resource:               "abc",
+		TokenCalculateStrategy: flow.Direct,
+		ControlBehavior:        flow.Reject,
+		Threshold:              math.MaxFloat64,
+		StatIntervalInMs:       1000,
+		RelationStrategy:       flow.CurrentResource,
+	}
+	flow.LoadRules([]*flow.Rule{rule})
+}
+
+func loadWarmUpRejectRule() {
+	rule := &flow.Rule{
+		Resource:               "abc",
+		TokenCalculateStrategy: flow.WarmUp,
+		ControlBehavior:        flow.Reject,
+		Threshold:              math.MaxFloat64,
+		WarmUpPeriodSec:        10,
+		WarmUpColdFactor:       3,
+		StatIntervalInMs:       1000,
+	}
+	flow.LoadRules([]*flow.Rule{rule})
+}
+
+func Benchmark_DirectReject_SlotCheck_4(b *testing.B) {
+	loadDirectRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_DirectReject_SlotCheck_8(b *testing.B) {
+	loadDirectRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_DirectReject_SlotCheck_16(b *testing.B) {
+	loadDirectRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_DirectReject_SlotCheck_32(b *testing.B) {
+	loadDirectRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_WarmUpReject_SlotCheck_4(b *testing.B) {
+	loadWarmUpRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_WarmUpReject_SlotCheck_8(b *testing.B) {
+	loadWarmUpRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_WarmUpReject_SlotCheck_16(b *testing.B) {
+	loadWarmUpRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_WarmUpReject_SlotCheck_32(b *testing.B) {
+	loadWarmUpRejectRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
enhance flow benchmark test

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
增加了flow 的benchmark test, 测试flow.slot.Check()

### Describe how to verify it
run tests/core/flow/flow_benchmark_test.go

### Special notes for reviews
以下测试均在windows 64， 8c环境下进行
```
load flow.Rule{
		Resource:               "abc",
		TokenCalculateStrategy: flow.Direct,
		ControlBehavior:        flow.Reject,
		Threshold:              10,
		StatIntervalInMs:       1000,
		RelationStrategy:       flow.CurrentResource,}
goos: windows
goarch: amd64
Benchmark_DirectReject_SlotCheck_4-8     6016041               231 ns/op               160 B/op          1 allocs/op
Benchmark_DirectReject_SlotCheck_8-8     6468952               214 ns/op               160 B/op          1 allocs/op
```

```
load flow.Rule{
		Resource:               "abc",
		TokenCalculateStrategy: flow.WarmUp,
		ControlBehavior:        flow.Reject,
		Threshold:              100,
		WarmUpPeriodSec:        10,
		WarmUpColdFactor:       3,
		StatIntervalInMs:       1000,}
goos: windows
goarch: amd64
Benchmark_WarmUpReject_SlotCheck_4-8     2993080               502 ns/op               320 B/op          2 allocs/op
Benchmark_WarmUpReject_SlotCheck_8-8     3149778               452 ns/op               320 B/op          2 allocs/op
```