### PR TITLE
Add isolation slot benchmark

### DIFF
--- a/tests/benchmark/isolation/isolation_slot_benchmark_test.go
+++ b/tests/benchmark/isolation/isolation_slot_benchmark_test.go
@@ -1,0 +1,81 @@
+package isolation
+
+import (
+	"log"
+	"math"
+	"testing"
+
+	"github.com/alibaba/sentinel-golang/api"
+	"github.com/alibaba/sentinel-golang/core/isolation"
+)
+
+func init() {
+	rule := &isolation.Rule{
+		Resource:   "abc",
+		MetricType: isolation.Concurrency,
+		Threshold:  math.MaxInt32,
+	}
+	if _, err := isolation.LoadRules([]*isolation.Rule{rule}); err != nil {
+		log.Fatalf("Load rule err: %s", err.Error())
+	}
+}
+
+func doCheck() {
+	if se, err := api.Entry("abc"); err == nil {
+		se.Exit()
+	} else {
+		log.Fatalf("Block err: %s", err.Error())
+	}
+}
+
+func Benchmark_IsolationSlotCheck_Loop(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doCheck()
+	}
+}
+
+func Benchmark_IsolationSlotCheck_Concurrency4(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_IsolationSlotCheck_Concurrency8(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_IsolationSlotCheck_Concurrency16(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_IsolationSlotCheck_Concurrency32(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add isolation slot benchmark.

Below is a benchmark result on my local machine.
```
goos: darwin
goarch: amd64
pkg: github.com/alibaba/sentinel-golang/tests/benchmark/isolation
Benchmark_IsolationSlotCheck_Loop-4              1292761               909 ns/op             120 B/op          4 allocs/op
Benchmark_IsolationSlotCheck_Concurrency4-4      2840018               442 ns/op             120 B/op          4 allocs/op
Benchmark_IsolationSlotCheck_Concurrency8-4      2446152               599 ns/op             120 B/op          4 allocs/op
Benchmark_IsolationSlotCheck_Concurrency16-4     2040709               696 ns/op             120 B/op          4 allocs/op
Benchmark_IsolationSlotCheck_Concurrency32-4     2602790               448 ns/op             120 B/op          4 allocs/op
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews