### PR TITLE
Add circuitbreaker benchmark test

### DIFF
--- a/tests/benchmark/circuitbreaker/circuitbreaker_benchmark_test.go
+++ b/tests/benchmark/circuitbreaker/circuitbreaker_benchmark_test.go
@@ -1,0 +1,198 @@
+package circuitbreaker
+
+import (
+	"log"
+	"testing"
+
+	"github.com/alibaba/sentinel-golang/api"
+	"github.com/alibaba/sentinel-golang/core/circuitbreaker"
+)
+
+func doCheck() {
+	if se, err := api.Entry("abc"); err == nil {
+		se.Exit()
+	} else {
+		log.Fatalf("Block err: %s", err.Error())
+	}
+}
+
+func loadSlowRequestRatioRule() {
+	rule := &circuitbreaker.Rule{
+		Resource:         "abc",
+		Strategy:         circuitbreaker.SlowRequestRatio,
+		RetryTimeoutMs:   1000,
+		MinRequestAmount: 5,
+		StatIntervalMs:   1000,
+		MaxAllowedRtMs:   20,
+		Threshold:        0.1,
+	}
+	circuitbreaker.LoadRules([]*circuitbreaker.Rule{rule})
+}
+
+func loadErrorRatioRule() {
+	rule := &circuitbreaker.Rule{
+		Resource:         "abc",
+		Strategy:         circuitbreaker.ErrorRatio,
+		RetryTimeoutMs:   1000,
+		MinRequestAmount: 5,
+		StatIntervalMs:   1000,
+		Threshold:        0.3,
+	}
+	circuitbreaker.LoadRules([]*circuitbreaker.Rule{rule})
+}
+
+func loadErrorCountRule() {
+	rule := &circuitbreaker.Rule{
+		Resource:         "abc",
+		Strategy:         circuitbreaker.ErrorCount,
+		RetryTimeoutMs:   1000,
+		MinRequestAmount: 5,
+		StatIntervalMs:   1000,
+		Threshold:        10.0,
+	}
+	circuitbreaker.LoadRules([]*circuitbreaker.Rule{rule})
+}
+
+func Benchmark_SlowRequestRatio_SlotCheck_4(b *testing.B) {
+	loadSlowRequestRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_SlowRequestRatio_SlotCheck_8(b *testing.B) {
+	loadSlowRequestRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_SlowRequestRatio_SlotCheck_16(b *testing.B) {
+	loadSlowRequestRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_SlowRequestRatio_SlotCheck_32(b *testing.B) {
+	loadSlowRequestRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorRatio_SlotCheck_4(b *testing.B) {
+	loadErrorRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorRatio_SlotCheck_8(b *testing.B) {
+	loadErrorRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorRatio_SlotCheck_16(b *testing.B) {
+	loadErrorRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorRatio_SlotCheck_32(b *testing.B) {
+	loadErrorRatioRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorCount_SlotCheck_4(b *testing.B) {
+	loadErrorCountRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorCount_SlotCheck_8(b *testing.B) {
+	loadErrorCountRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(8)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorCount_SlotCheck_16(b *testing.B) {
+	loadErrorCountRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(16)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}
+
+func Benchmark_ErrorCount_SlotCheck_32(b *testing.B) {
+	loadErrorCountRule()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(32)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			doCheck()
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add circuitbreaker benchmark test
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
增加了circuitbreaker的benchmark test, 测试circuitbreaker.slot.Check()

### Describe how to verify it
run tests/core/circuitbreaker/circuitbreaker_benchmark_test.go

### Special notes for reviews
以下测试均在windows 64， 8c环境下进行
```
load circuitbreaker.Rule{
		Resource:         "abc",
		Strategy:         circuitbreaker.SlowRequestRatio,
		RetryTimeoutMs:   1000,
		MinRequestAmount: 5,
		StatIntervalMs:   1000,
		MaxAllowedRtMs:   20,
		Threshold:        0.1,}
goos: windowsp
goarch: amd64
Benchmark_SlowRequestRatio_SlotCheck_4-8     11569263               92.2 ns/op               16 B/op          1 allocs/op
Benchmark_SlowRequestRatio_SlotCheck_8-8     12800313               109 ns/op                16 B/op          1 allocs/op
```
```
load circuitbreaker.Rule{
		Resource:         "abc",
		Strategy:         circuitbreaker.ErrorRatio,
		RetryTimeoutMs:   1000,
		MinRequestAmount: 5,
		StatIntervalMs:   1000,
		Threshold:        0.3,}
goos: windows
goarch: amd64
Benchmark_ErrorRatio_SlotCheck_4-8     11917897               107 ns/op               16 B/op          1 allocs/op
Benchmark_ErrorRatio_SlotCheck_8-8     13369311               87.8 ns/op               16 B/op          1 allocs/op
```
```
load circuitbreaker.Rule{
		Resource:         "abc",
		Strategy:         circuitbreaker.ErrorCount,
		RetryTimeoutMs:   1000,
		MinRequestAmount: 5,
		StatIntervalMs:   1000,
		Threshold:        10.0,}
goos: windows
goarch: amd64
Benchmark_ErrorCount_SlotCheck_4-8     18511376               57.5 ns/op               16 B/op          1 allocs/op
Benchmark_ErrorCount_SlotCheck_8-8     20394392               57.6 ns/op               16 B/op          1 allocs/op
```