### PR TITLE
fix bug in circuit_breaker.go about SlowRequestRatio

### DIFF
--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -290,7 +290,7 @@ func (b *slowRtCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 		return
 	}
 
-	if slowRatio > b.maxSlowRequestRatio {
+	if slowRatio > b.maxSlowRequestRatio || util.Float64Equals(slowRatio, b.maxSlowRequestRatio) {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:
@@ -468,7 +468,7 @@ func (b *errorRatioCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	if errorRatio >= b.errorRatioThreshold {
+	if errorRatio > b.errorRatioThreshold || util.Float64Equals(errorRatio, b.errorRatioThreshold) {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -468,7 +468,7 @@ func (b *errorRatioCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	if errorRatio > b.errorRatioThreshold {
+	if errorRatio >= b.errorRatioThreshold {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:
@@ -642,7 +642,7 @@ func (b *errorCountCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	if errorCount > b.errorCountThreshold {
+	if errorCount >= b.errorCountThreshold {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -290,7 +290,7 @@ func (b *slowRtCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 		return
 	}
 
-	if slowRatio >= b.maxSlowRequestRatio {
+	if slowRatio > b.maxSlowRequestRatio {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:
@@ -468,7 +468,7 @@ func (b *errorRatioCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	if errorRatio >= b.errorRatioThreshold {
+	if errorRatio > b.errorRatioThreshold {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -290,7 +290,7 @@ func (b *slowRtCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 		return
 	}
 
-	// Special case where maxSlowRequestRatio is set to 1.0 should be handled
+	// Special case when maxSlowRequestRatio is set to 1.0 should be handled
 	if slowRatio > b.maxSlowRequestRatio || (slowRatio == 1.0 && b.maxSlowRequestRatio == 1.0) {
 		curStatus = b.CurrentState()
 		switch curStatus {
@@ -469,7 +469,8 @@ func (b *errorRatioCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	if errorRatio > b.errorRatioThreshold {
+	// Special case when errorRatioThreshold is set to 1.0 should be handled
+	if errorRatio > b.errorRatioThreshold || (b.errorRatioThreshold == 1.0 && errorRatio == 1.0) {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -290,8 +290,7 @@ func (b *slowRtCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 		return
 	}
 
-	// Special case when maxSlowRequestRatio is set to 1.0 should be handled
-	if slowRatio > b.maxSlowRequestRatio || (slowRatio == 1.0 && b.maxSlowRequestRatio == 1.0) {
+	if slowRatio >= b.maxSlowRequestRatio {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:
@@ -469,8 +468,7 @@ func (b *errorRatioCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 	if totalCount < b.minRequestAmount {
 		return
 	}
-	// Special case when errorRatioThreshold is set to 1.0 should be handled
-	if errorRatio > b.errorRatioThreshold || (b.errorRatioThreshold == 1.0 && errorRatio == 1.0) {
+	if errorRatio >= b.errorRatioThreshold {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/circuit_breaker.go
+++ b/core/circuitbreaker/circuit_breaker.go
@@ -290,7 +290,8 @@ func (b *slowRtCircuitBreaker) OnRequestComplete(rt uint64, err error) {
 		return
 	}
 
-	if slowRatio > b.maxSlowRequestRatio {
+	// Special case where maxSlowRequestRatio is set to 1.0 should be handled
+	if slowRatio > b.maxSlowRequestRatio || (slowRatio == 1.0 && b.maxSlowRequestRatio == 1.0) {
 		curStatus = b.CurrentState()
 		switch curStatus {
 		case Closed:

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -357,11 +357,11 @@ func IsValid(r *Rule) error {
 	if r.Threshold < 0.0 {
 		return errors.New("invalid Threshold")
 	}
-	if r.Strategy == SlowRequestRatio && r.Threshold > 1.0 {
-		return errors.New("invalid slow request ratio threshold (valid range: [0.0, 1.0])")
+	if r.Strategy == SlowRequestRatio && r.Threshold >= 1.0 {
+		return errors.New("invalid slow request ratio threshold (valid range: [0.0, 1.0) )")
 	}
-	if r.Strategy == ErrorRatio && r.Threshold > 1.0 {
-		return errors.New("invalid error ratio threshold (valid range: [0.0, 1.0])")
+	if r.Strategy == ErrorRatio && r.Threshold >= 1.0 {
+		return errors.New("invalid error ratio threshold (valid range: [0.0, 1.0) )")
 	}
 	return nil
 }

--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -357,11 +357,11 @@ func IsValid(r *Rule) error {
 	if r.Threshold < 0.0 {
 		return errors.New("invalid Threshold")
 	}
-	if r.Strategy == SlowRequestRatio && r.Threshold >= 1.0 {
-		return errors.New("invalid slow request ratio threshold (valid range: [0.0, 1.0) )")
+	if r.Strategy == SlowRequestRatio && r.Threshold > 1.0 {
+		return errors.New("invalid slow request ratio threshold (valid range: [0.0, 1.0])")
 	}
-	if r.Strategy == ErrorRatio && r.Threshold >= 1.0 {
-		return errors.New("invalid error ratio threshold (valid range: [0.0, 1.0) )")
+	if r.Strategy == ErrorRatio && r.Threshold > 1.0 {
+		return errors.New("invalid error ratio threshold (valid range: [0.0, 1.0])")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
when slowRequestRatio was set to 1.0d, requests will **never** be blocked. Because the currentRatio will never be bigger than 100%

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Special treatment for case when slowRequestRatio was set to 1.0d

### Describe how to verify it


### Special notes for reviews