### PR TITLE
Loading hotspot rule supports cache

### DIFF
--- a/core/hotspot/rule_manager.go
+++ b/core/hotspot/rule_manager.go
@@ -2,6 +2,7 @@ package hotspot
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/alibaba/sentinel-golang/core/misc"
@@ -20,6 +21,7 @@ var (
 	tcGenFuncMap = make(map[ControlBehavior]TrafficControllerGenFunc, 4)
 	tcMap        = make(trafficControllerMap)
 	tcMux        = new(sync.RWMutex)
+	currentRules = make([]*Rule, 0)
 )
 
 func init() {
@@ -64,6 +66,14 @@ func getTrafficControllersFor(res string) []TrafficShapingController {
 // bool: indicates whether the internal map has been changed;
 // error: indicates whether occurs the error.
 func LoadRules(rules []*Rule) (bool, error) {
+	tcMux.RLock()
+	isEqual := reflect.DeepEqual(currentRules, rules)
+	tcMux.RUnlock()
+	if isEqual {
+		logging.Info("[HotSpot] Load rules repetition, does not load")
+		return false, nil
+	}
+
 	err := onRuleUpdate(rules)
 	return true, err
 }
@@ -199,6 +209,7 @@ func onRuleUpdate(rules []*Rule) (err error) {
 		}
 	}
 	tcMap = m
+	currentRules = rules
 
 	return nil
 }

--- a/core/hotspot/rule_manager_test.go
+++ b/core/hotspot/rule_manager_test.go
@@ -279,3 +279,43 @@ func Test_onRuleUpdate(t *testing.T) {
 
 	tcMap = make(trafficControllerMap)
 }
+
+func TestLoadRules(t *testing.T) {
+	t.Run("loadSameRules", func(t *testing.T) {
+		specific := make(map[interface{}]int64)
+		specific["sss"] = 1
+		specific["123"] = 3
+
+		_, err := LoadRules([]*Rule{
+			{
+				ID:                "1",
+				Resource:          "abc",
+				MetricType:        Concurrency,
+				ControlBehavior:   Reject,
+				ParamIndex:        0,
+				Threshold:         100.0,
+				MaxQueueingTimeMs: 0,
+				BurstCount:        10,
+				DurationInSec:     1,
+				SpecificItems:     specific,
+			},
+		})
+		assert.Nil(t, err)
+		ok, err := LoadRules([]*Rule{
+			{
+				ID:                "1",
+				Resource:          "abc",
+				MetricType:        Concurrency,
+				ControlBehavior:   Reject,
+				ParamIndex:        0,
+				Threshold:         100.0,
+				MaxQueueingTimeMs: 0,
+				BurstCount:        10,
+				DurationInSec:     1,
+				SpecificItems:     specific,
+			},
+		})
+		assert.Nil(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -202,8 +202,8 @@ func HotSpotParamRulesUpdater(data interface{}) error {
 			fmt.Sprintf("Fail to type assert data to []hotspot.Rule or []*hotspot.Rule, in fact, data: %+v", data),
 		)
 	}
-	succ, err := hotspot.LoadRules(rules)
-	if succ && err == nil {
+	_, err := hotspot.LoadRules(rules)
+	if err == nil {
 		return nil
 	}
 	return NewError(


### PR DESCRIPTION
Describe what this PR does / why we need it
In order to avoid the meaningless updates to the property, downstream of property manager should
cache last update value to check consistency.

Does this pull request fix one issue?
Fix:#111

Describe how you did it
Using reflect.deepequal,maybe we need to think about performance

Describe how to verify it
ut

Special notes for reviews