### PR TITLE
Loading isolation rule supports cache

### DIFF
--- a/core/hotspot/rule_manager.go
+++ b/core/hotspot/rule_manager.go
@@ -76,7 +76,7 @@ func LoadRules(rules []*Rule) (bool, error) {
 	isEqual := reflect.DeepEqual(currentRules, rules)
 	tcMux.RUnlock()
 	if isEqual {
-		logging.Info("[HotSpot] Load rules repetition, does not load")
+		logging.Info("[HotSpot] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
 	}
 

--- a/core/isolation/rule_manager.go
+++ b/core/isolation/rule_manager.go
@@ -1,24 +1,37 @@
 package isolation
 
 import (
+	"reflect"
 	"sync"
 
 	"github.com/alibaba/sentinel-golang/core/misc"
-	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
+
+	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/pkg/errors"
 )
 
 var (
-	ruleMap = make(map[string][]*Rule)
-	rwMux   = &sync.RWMutex{}
+	ruleMap      = make(map[string][]*Rule)
+	rwMux        = &sync.RWMutex{}
+	currentRules = make([]*Rule, 0)
 )
 
 // LoadRules loads the given isolation rules to the rule manager, while all previous rules will be replaced.
-func LoadRules(rules []*Rule) (updated bool, err error) {
-	updated = true
-	err = nil
+func LoadRules(rules []*Rule) (bool, error) {
+	rwMux.RLock()
+	isEqual := reflect.DeepEqual(currentRules, rules)
+	rwMux.RUnlock()
+	if isEqual {
+		logging.Info("[Isolation] Load rules repetition, does not load")
+		return false, nil
+	}
 
+	err := onRuleUpdate(rules)
+	return true, err
+}
+
+func onRuleUpdate(rules []*Rule) (err error) {
 	m := make(map[string][]*Rule, len(rules))
 	for _, r := range rules {
 		if e := IsValid(r); e != nil {
@@ -47,6 +60,7 @@ func LoadRules(rules []*Rule) (updated bool, err error) {
 		}
 	}
 	ruleMap = m
+	currentRules = rules
 	return
 }
 

--- a/core/isolation/rule_manager.go
+++ b/core/isolation/rule_manager.go
@@ -5,9 +5,8 @@ import (
 	"sync"
 
 	"github.com/alibaba/sentinel-golang/core/misc"
-	"github.com/alibaba/sentinel-golang/util"
-
 	"github.com/alibaba/sentinel-golang/logging"
+	"github.com/alibaba/sentinel-golang/util"
 	"github.com/pkg/errors"
 )
 
@@ -18,12 +17,13 @@ var (
 )
 
 // LoadRules loads the given isolation rules to the rule manager, while all previous rules will be replaced.
+// the first returned value indicates whether do real load operation, if the rules is the same with previous rules, return false
 func LoadRules(rules []*Rule) (bool, error) {
 	rwMux.RLock()
 	isEqual := reflect.DeepEqual(currentRules, rules)
 	rwMux.RUnlock()
 	if isEqual {
-		logging.Info("[Isolation] Load rules repetition, does not load")
+		logging.Info("[Isolation] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
 	}
 

--- a/core/isolation/rule_manager_test.go
+++ b/core/isolation/rule_manager_test.go
@@ -36,4 +36,24 @@ func TestLoadRules(t *testing.T) {
 		err = ClearRules()
 		assert.True(t, err == nil)
 	})
+
+	t.Run("loadSameRules", func(t *testing.T) {
+		_, err := LoadRules([]*Rule{
+			{
+				Resource:   "abc1",
+				MetricType: Concurrency,
+				Threshold:  100,
+			},
+		})
+		assert.Nil(t, err)
+		ok, err := LoadRules([]*Rule{
+			{
+				Resource:   "abc1",
+				MetricType: Concurrency,
+				Threshold:  100,
+			},
+		})
+		assert.Nil(t, err)
+		assert.False(t, ok)
+	})
 }


### PR DESCRIPTION
Describe what this PR does / why we need it
In order to avoid the meaningless updates to the property, downstream of property manager should
cache last update value to check consistency.

Does this pull request fix one issue?
Fix:#111

Describe how you did it
Using reflect.deepequal,maybe we need to think about performance

Describe how to verify it
ut

Special notes for reviews