### PR TITLE
Loading circuitbreaker rule supports cache

### DIFF
--- a/core/circuitbreaker/rule_manager.go
+++ b/core/circuitbreaker/rule_manager.go
@@ -122,7 +122,7 @@ func LoadRules(rules []*Rule) (bool, error) {
 	isEqual := reflect.DeepEqual(currentRules, rules)
 	updateMux.RUnlock()
 	if isEqual {
-		logging.Info("[CircuitBreaker] Load rules repetition, does not load")
+		logging.Info("[CircuitBreaker] Load rules is the same with current rules, so ignore load operation.")
 		return false, nil
 	}
 

--- a/core/circuitbreaker/rule_manager_test.go
+++ b/core/circuitbreaker/rule_manager_test.go
@@ -340,3 +340,33 @@ func TestRemoveCircuitBreakerGenerator(t *testing.T) {
 		assert.Error(t, err, "not allowed to remove the generator for default circuit breaking strategies")
 	})
 }
+
+func TestLoadRules(t *testing.T) {
+	t.Run("loadSameRules", func(t *testing.T) {
+		_, err := LoadRules([]*Rule{
+			{
+				Resource:         "abc",
+				Strategy:         SlowRequestRatio,
+				RetryTimeoutMs:   1000,
+				MinRequestAmount: 5,
+				StatIntervalMs:   1000,
+				MaxAllowedRtMs:   20,
+				Threshold:        0.1,
+			},
+		})
+		assert.Nil(t, err)
+		ok, err := LoadRules([]*Rule{
+			{
+				Resource:         "abc",
+				Strategy:         SlowRequestRatio,
+				RetryTimeoutMs:   1000,
+				MinRequestAmount: 5,
+				StatIntervalMs:   1000,
+				MaxAllowedRtMs:   20,
+				Threshold:        0.1,
+			},
+		})
+		assert.Nil(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -140,8 +140,8 @@ func CircuitBreakerRulesUpdater(data interface{}) error {
 			fmt.Sprintf("Fail to type assert data to []*circuitbreaker.Rule, in fact, data: %+v", data),
 		)
 	}
-	succ, err := cb.LoadRules(rules)
-	if succ && err == nil {
+	_, err := cb.LoadRules(rules)
+	if err == nil {
 		return nil
 	}
 	return NewError(


### PR DESCRIPTION
Describe what this PR does / why we need it
In order to avoid the meaningless updates to the property, downstream of property manager should
cache last update value to check consistency.

Does this pull request fix one issue?
Fix:#111

Describe how you did it
Using reflect.deepequal,maybe we need to think about performance

Describe how to verify it
ut

Special notes for reviews