### PR TITLE
热点规则增加ParamKey，方便快速从大量的键值对中指定需要热点限流的值

### DIFF
--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -79,7 +79,10 @@ type Rule struct {
 	// ParamIndex is the index in context arguments slice.
 	// if ParamIndex is great than or equals to zero, ParamIndex means the <ParamIndex>-th parameter
 	// if ParamIndex is the negative, ParamIndex means the reversed <ParamIndex>-th parameter
-	ParamIndex int `json:"paramIndex"`
+	ParamIndex int    `json:"paramIndex"`
+	// ParamKey is the key in context attachments map.
+	// ParamKey can be used as a supplement to ParamIndex to facilitate rules to quickly obtain parameter from a large number of parameters
+	ParamKey   string `json:"paramKey"`
 	// Threshold is the threshold to trigger rejection
 	Threshold int64 `json:"threshold"`
 	// MaxQueueingTimeMs only takes effect when ControlBehavior is Throttling and MetricType is QPS

--- a/core/hotspot/slot.go
+++ b/core/hotspot/slot.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/logging"
 )
 
 const (
@@ -41,57 +40,35 @@ func (s *Slot) Order() uint32 {
 	return RuleCheckSlotOrder
 }
 
-// matchArg matches the arg from args based on TrafficShapingController
-// return nil if match failed.
-func matchArg(tc TrafficShapingController, args []interface{}) interface{} {
-	if tc == nil {
-		return nil
-	}
-	idx := tc.BoundParamIndex()
-	if idx < 0 {
-		idx = len(args) + idx
-	}
-	if idx < 0 {
-		if logging.DebugEnabled() {
-			logging.Debug("[Slot matchArg] The param index of hotspot traffic shaping controller is invalid", "args", args, "paramIndex", tc.BoundParamIndex())
-		}
-		return nil
-	}
-	if idx >= len(args) {
-		if logging.DebugEnabled() {
-			logging.Debug("[Slot matchArg] The argument in index doesn't exist", "args", args, "paramIndex", tc.BoundParamIndex())
-		}
-		return nil
-	}
-	return args[idx]
-}
-
 func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 	res := ctx.Resource.Name()
-	args := ctx.Input.Args
+
 	batch := int64(ctx.Input.BatchCount)
 
 	result := ctx.RuleCheckResult
 	tcs := getTrafficControllersFor(res)
 	for _, tc := range tcs {
-		arg := matchArg(tc, args)
-		if arg == nil {
+		args := tc.ExtractArgs(ctx)
+		if args == nil || len(args) == 0 {
 			continue
 		}
-		r := canPassCheck(tc, arg, batch)
-		if r == nil {
-			continue
-		}
-		if r.Status() == base.ResultStatusBlocked {
-			return r
-		}
-		if r.Status() == base.ResultStatusShouldWait {
-			if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
-				// Handle waiting action.
-				time.Sleep(nanosToWait)
+		for _, arg := range args {
+			r := canPassCheck(tc, arg, batch)
+			if r == nil {
+				continue
 			}
-			continue
+			if r.Status() == base.ResultStatusBlocked {
+				return r
+			}
+			if r.Status() == base.ResultStatusShouldWait {
+				if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
+					// Handle waiting action.
+					time.Sleep(nanosToWait)
+				}
+				continue
+			}
 		}
+
 	}
 	return result
 }

--- a/core/hotspot/slot_test.go
+++ b/core/hotspot/slot_test.go
@@ -15,11 +15,8 @@
 package hotspot
 
 import (
-	"reflect"
-	"testing"
-
 	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -52,53 +49,8 @@ func (m *TrafficShapingControllerMock) Replace(r *Rule) {
 	return
 }
 
-func Test_matchArg(t *testing.T) {
-	t.Run("Test_matchArg", func(t *testing.T) {
-		args := make([]interface{}, 10)
-		args[0] = 1
-		args[1] = 2
-		args[2] = 3
-		args[3] = 4
-		args[4] = 5
-		args[5] = 6
-		args[6] = 7
-		args[7] = 8
-		args[8] = 9
-		args[9] = 10
-
-		tcMock := &TrafficShapingControllerMock{}
-		tcMock.On("BoundParamIndex").Return(0)
-		ret0 := matchArg(tcMock, args)
-		assert.True(t, reflect.DeepEqual(ret0, 1))
-
-		tcMock1 := &TrafficShapingControllerMock{}
-		tcMock1.On("BoundParamIndex").Return(5)
-		ret1 := matchArg(tcMock1, args)
-		assert.True(t, reflect.DeepEqual(ret1, 6))
-
-		tcMock2 := &TrafficShapingControllerMock{}
-		tcMock2.On("BoundParamIndex").Return(9)
-		ret2 := matchArg(tcMock2, args)
-		assert.True(t, reflect.DeepEqual(ret2, 10))
-
-		tcMock3 := &TrafficShapingControllerMock{}
-		tcMock3.On("BoundParamIndex").Return(-1)
-		ret3 := matchArg(tcMock3, args)
-		assert.True(t, reflect.DeepEqual(ret3, 10))
-
-		tcMock4 := &TrafficShapingControllerMock{}
-		tcMock4.On("BoundParamIndex").Return(-10)
-		ret4 := matchArg(tcMock4, args)
-		assert.True(t, reflect.DeepEqual(ret4, 1))
-
-		tcMock5 := &TrafficShapingControllerMock{}
-		tcMock5.On("BoundParamIndex").Return(10)
-		ret5 := matchArg(tcMock5, args)
-		assert.True(t, ret5 == nil)
-
-		tcMock6 := &TrafficShapingControllerMock{}
-		tcMock6.On("BoundParamIndex").Return(-11)
-		ret6 := matchArg(tcMock6, args)
-		assert.True(t, ret6 == nil)
-	})
+func (m *TrafficShapingControllerMock) ExtractArgs(ctx *base.EntryContext) []interface{} {
+	_ = m.Called()
+	ret := []interface{}{ctx.Input.Args[m.BoundParamIndex()]}
+	return ret
 }

--- a/example/hotspot_param_flow/concurrency/hotspot_params_concurrency_example.go
+++ b/example/hotspot_param_flow/concurrency/hotspot_params_concurrency_example.go
@@ -35,6 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	testKey := "testKey"
 
 	// the max concurrency is 8
 	_, err = hotspot.LoadRules([]*hotspot.Rule{
@@ -42,6 +43,7 @@ func main() {
 			Resource:      "abc",
 			MetricType:    hotspot.Concurrency,
 			ParamIndex:    0,
+			ParamKey:      testKey,
 			Threshold:     8,
 			DurationInSec: 0,
 		},
@@ -79,7 +81,12 @@ func main() {
 	}
 
 	for {
-		e, b := sentinel.Entry("abc", sentinel.WithArgs(false, uint32(9)))
+		e, b := sentinel.Entry("abc",
+			sentinel.WithArgs(false, uint32(9),
+				sentinel.WithAttachments(map[interface{}]interface{}{
+					testKey: rand.Uint64() % 10,
+				}),
+			))
 		if b != nil {
 			// Blocked. We could get the block reason from the BlockError.
 			time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)

--- a/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
+++ b/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
@@ -26,8 +26,7 @@ import (
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/config"
 	"github.com/alibaba/sentinel-golang/core/hotspot"
-	"github.com/alibaba/sentinel-golang/logging":q
-
+	"github.com/alibaba/sentinel-golang/logging"
 )
 
 type fooStruct struct {

--- a/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
+++ b/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
@@ -15,14 +15,19 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"time"
 
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/core/stat"
+
 	sentinel "github.com/alibaba/sentinel-golang/api"
 	"github.com/alibaba/sentinel-golang/core/config"
 	"github.com/alibaba/sentinel-golang/core/hotspot"
-	"github.com/alibaba/sentinel-golang/logging"
+	"github.com/alibaba/sentinel-golang/logging":q
+
 )
 
 type fooStruct struct {
@@ -37,6 +42,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	rand.Seed(time.Now().UnixNano())
+	testKey := "testKey"
 
 	_, err = hotspot.LoadRules([]*hotspot.Rule{
 		{
@@ -57,10 +64,35 @@ func main() {
 			BurstCount:      0,
 			DurationInSec:   1,
 		},
+		{
+			Resource:        "efg",
+			MetricType:      hotspot.QPS,
+			ControlBehavior: hotspot.Reject,
+			ParamKey:        testKey,
+			Threshold:       50,
+			BurstCount:      0,
+			DurationInSec:   1,
+		},
 	})
 	if err != nil {
 		log.Fatalf("Unexpected error: %+v", err)
 		return
+	}
+	for _, resource := range []string{"abc", "def", "efg"} {
+		go func() {
+			node := stat.GetOrCreateResourceNode(resource, base.ResTypeCommon)
+			for {
+				logging.Info("[HotSpot QPS] "+resource,
+					"pass", node.GetQPS(base.MetricEventPass),
+					"block", node.GetQPS(base.MetricEventBlock),
+					"complete", node.GetQPS(base.MetricEventComplete),
+					"error", node.GetQPS(base.MetricEventError),
+					"rt", node.GetQPS(base.MetricEventRt),
+					//"\n total", node.GetQPS(base.MetricEventTotal),
+				)
+				time.Sleep(time.Duration(1000) * time.Millisecond)
+			}
+		}()
 	}
 
 	logging.Info("[HotSpot Reject] Sentinel Go hot-spot param flow control demo is running. You may see the pass/block metric in the metric log.")
@@ -81,15 +113,34 @@ func main() {
 			}
 		}()
 	}
+	go func() {
+		for {
+			e, b := sentinel.Entry("def", sentinel.WithArgs(false, 9, "ahas", fooStruct{rand.Int63() % 5}))
+			if b != nil {
+				// Blocked. We could get the block reason from the BlockError.
+				time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)
+			} else {
+				// Passed, wrap the logic here.
+				time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)
+				// Be sure the entry is exited finally.
+				e.Exit()
+			}
+		}
+	}()
 
 	for {
-		e, b := sentinel.Entry("def", sentinel.WithArgs(false, 9, "ahas", fooStruct{rand.Int63() % 5}))
+		val := fmt.Sprintf("test%v", rand.Int31()%10)
+		//fmt.Printf("====%v\n", val)
+		e, b := sentinel.Entry("efg",
+			sentinel.WithAttachments(map[interface{}]interface{}{
+				testKey: val,
+			}))
 		if b != nil {
 			// Blocked. We could get the block reason from the BlockError.
 			time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)
 		} else {
 			// Passed, wrap the logic here.
-			time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Uint64()%2) * time.Millisecond)
 			// Be sure the entry is exited finally.
 			e.Exit()
 		}
@@ -97,4 +148,5 @@ func main() {
 
 	// The QPS of abc is about: 1500
 	// The QPS of def is about: 50
+	// The QPS of efg is about: 500
 }

--- a/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
+++ b/example/hotspot_param_flow/qps_reject/hotspot_params_qps_reject_example.go
@@ -78,10 +78,10 @@ func main() {
 		return
 	}
 	for _, resource := range []string{"abc", "def", "efg"} {
-		go func() {
-			node := stat.GetOrCreateResourceNode(resource, base.ResTypeCommon)
+		go func(name string) {
+			node := stat.GetOrCreateResourceNode(name, base.ResTypeCommon)
 			for {
-				logging.Info("[HotSpot QPS] "+resource,
+				logging.Info("[HotSpot QPS] "+name,
 					"pass", node.GetQPS(base.MetricEventPass),
 					"block", node.GetQPS(base.MetricEventBlock),
 					"complete", node.GetQPS(base.MetricEventComplete),
@@ -91,7 +91,7 @@ func main() {
 				)
 				time.Sleep(time.Duration(1000) * time.Millisecond)
 			}
-		}()
+		}(resource)
 	}
 
 	logging.Info("[HotSpot Reject] Sentinel Go hot-spot param flow control demo is running. You may see the pass/block metric in the metric log.")
@@ -129,7 +129,6 @@ func main() {
 
 	for {
 		val := fmt.Sprintf("test%v", rand.Int31()%10)
-		//fmt.Printf("====%v\n", val)
 		e, b := sentinel.Entry("efg",
 			sentinel.WithAttachments(map[interface{}]interface{}{
 				testKey: val,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
热点参数规则中，增加ParamKey配合context attachments map ,方便快速从大量的键值对中指定需要热点限流的值. (alibaba#355)

### Describe what this PR does / why we need it
方便热点限流规则中，指定热点参数。
比如把系统参数、header中标定参数、业务参数，数据很多，不同业务需要的参数也不相同，加入把全部数据放入ctx.attachments 这样在规则中指定特点的key，很方便。

### Does this pull request fix one issue?
本次pr 已经增加ParamKey, 并且修改了对应的单元测试和example.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
规则增加ParamKey；
trafficShaper 也对应实现extractArg 接口，可以与已有的paramIndex 一起方便指定热点参数。

### Describe how to verify it
单元测试和example 中均验证过了

### Special notes for reviews
ParamKey 可以考虑变成[]string ，这样使用者除了指定单个参数外，还可以灵活的指定热点的规则。
例如ParamKey=[]string{"uid","merchant_id"} 这样可以让uid和merchant_id 作为联合参数作为热点。