### PR TITLE
热点规则增加ParamKey，方便快速从大量的键值对中指定需要热点限流的值 

### DIFF
--- a/core/hotspot/concurrency_stat_slot.go
+++ b/core/hotspot/concurrency_stat_slot.go
@@ -16,8 +16,9 @@ package hotspot
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/logging"

--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -79,7 +79,10 @@ type Rule struct {
 	// ParamIndex is the index in context arguments slice.
 	// if ParamIndex is great than or equals to zero, ParamIndex means the <ParamIndex>-th parameter
 	// if ParamIndex is the negative, ParamIndex means the reversed <ParamIndex>-th parameter
-	ParamIndex int `json:"paramIndex"`
+	ParamIndex int    `json:"paramIndex"`
+	// ParamKey is the key in context attachments map.
+	// ParamKey can be used as a supplement to ParamIndex to facilitate rules to quickly obtain parameter from a large number of parameters
+	ParamKey   string `json:"paramKey"`
 	// Threshold is the threshold to trigger rejection
 	Threshold int64 `json:"threshold"`
 	// MaxQueueingTimeMs only takes effect when ControlBehavior is Throttling and MetricType is QPS

--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -79,10 +79,10 @@ type Rule struct {
 	// ParamIndex is the index in context arguments slice.
 	// if ParamIndex is great than or equals to zero, ParamIndex means the <ParamIndex>-th parameter
 	// if ParamIndex is the negative, ParamIndex means the reversed <ParamIndex>-th parameter
-	ParamIndex int    `json:"paramIndex"`
+	ParamIndex int `json:"paramIndex"`
 	// ParamKey is the key in context attachments map.
 	// ParamKey can be used as a supplement to ParamIndex to facilitate rules to quickly obtain parameter from a large number of parameters
-	ParamKey   string `json:"paramKey"`
+	ParamKey string `json:"paramKey"`
 	// Threshold is the threshold to trigger rejection
 	Threshold int64 `json:"threshold"`
 	// MaxQueueingTimeMs only takes effect when ControlBehavior is Throttling and MetricType is QPS

--- a/core/hotspot/slot.go
+++ b/core/hotspot/slot.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/alibaba/sentinel-golang/logging"
 )
 
 const (
@@ -41,57 +40,35 @@ func (s *Slot) Order() uint32 {
 	return RuleCheckSlotOrder
 }
 
-// matchArg matches the arg from args based on TrafficShapingController
-// return nil if match failed.
-func matchArg(tc TrafficShapingController, args []interface{}) interface{} {
-	if tc == nil {
-		return nil
-	}
-	idx := tc.BoundParamIndex()
-	if idx < 0 {
-		idx = len(args) + idx
-	}
-	if idx < 0 {
-		if logging.DebugEnabled() {
-			logging.Debug("[Slot matchArg] The param index of hotspot traffic shaping controller is invalid", "args", args, "paramIndex", tc.BoundParamIndex())
-		}
-		return nil
-	}
-	if idx >= len(args) {
-		if logging.DebugEnabled() {
-			logging.Debug("[Slot matchArg] The argument in index doesn't exist", "args", args, "paramIndex", tc.BoundParamIndex())
-		}
-		return nil
-	}
-	return args[idx]
-}
-
 func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 	res := ctx.Resource.Name()
-	args := ctx.Input.Args
+
 	batch := int64(ctx.Input.BatchCount)
 
 	result := ctx.RuleCheckResult
 	tcs := getTrafficControllersFor(res)
 	for _, tc := range tcs {
-		arg := matchArg(tc, args)
-		if arg == nil {
+		args := tc.ExtractArgs(ctx)
+		if args == nil || len(args) == 0 {
 			continue
 		}
-		r := canPassCheck(tc, arg, batch)
-		if r == nil {
-			continue
-		}
-		if r.Status() == base.ResultStatusBlocked {
-			return r
-		}
-		if r.Status() == base.ResultStatusShouldWait {
-			if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
-				// Handle waiting action.
-				time.Sleep(nanosToWait)
+		for _, arg := range args {
+			r := canPassCheck(tc, arg, batch)
+			if r == nil {
+				continue
 			}
-			continue
+			if r.Status() == base.ResultStatusBlocked {
+				return r
+			}
+			if r.Status() == base.ResultStatusShouldWait {
+				if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
+					// Handle waiting action.
+					time.Sleep(nanosToWait)
+				}
+				continue
+			}
 		}
+
 	}
 	return result
 }

--- a/core/hotspot/slot.go
+++ b/core/hotspot/slot.go
@@ -16,9 +16,10 @@ package hotspot
 
 import (
 	"context"
+	"time"
+
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/errgo.v2/fmt/errors"
-	"time"
 
 	"github.com/alibaba/sentinel-golang/core/base"
 )

--- a/core/hotspot/slot_test.go
+++ b/core/hotspot/slot_test.go
@@ -15,11 +15,8 @@
 package hotspot
 
 import (
-	"reflect"
-	"testing"
-
 	"github.com/alibaba/sentinel-golang/core/base"
-	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -52,53 +49,8 @@ func (m *TrafficShapingControllerMock) Replace(r *Rule) {
 	return
 }
 
-func Test_matchArg(t *testing.T) {
-	t.Run("Test_matchArg", func(t *testing.T) {
-		args := make([]interface{}, 10)
-		args[0] = 1
-		args[1] = 2
-		args[2] = 3
-		args[3] = 4
-		args[4] = 5
-		args[5] = 6
-		args[6] = 7
-		args[7] = 8
-		args[8] = 9
-		args[9] = 10
-
-		tcMock := &TrafficShapingControllerMock{}
-		tcMock.On("BoundParamIndex").Return(0)
-		ret0 := matchArg(tcMock, args)
-		assert.True(t, reflect.DeepEqual(ret0, 1))
-
-		tcMock1 := &TrafficShapingControllerMock{}
-		tcMock1.On("BoundParamIndex").Return(5)
-		ret1 := matchArg(tcMock1, args)
-		assert.True(t, reflect.DeepEqual(ret1, 6))
-
-		tcMock2 := &TrafficShapingControllerMock{}
-		tcMock2.On("BoundParamIndex").Return(9)
-		ret2 := matchArg(tcMock2, args)
-		assert.True(t, reflect.DeepEqual(ret2, 10))
-
-		tcMock3 := &TrafficShapingControllerMock{}
-		tcMock3.On("BoundParamIndex").Return(-1)
-		ret3 := matchArg(tcMock3, args)
-		assert.True(t, reflect.DeepEqual(ret3, 10))
-
-		tcMock4 := &TrafficShapingControllerMock{}
-		tcMock4.On("BoundParamIndex").Return(-10)
-		ret4 := matchArg(tcMock4, args)
-		assert.True(t, reflect.DeepEqual(ret4, 1))
-
-		tcMock5 := &TrafficShapingControllerMock{}
-		tcMock5.On("BoundParamIndex").Return(10)
-		ret5 := matchArg(tcMock5, args)
-		assert.True(t, ret5 == nil)
-
-		tcMock6 := &TrafficShapingControllerMock{}
-		tcMock6.On("BoundParamIndex").Return(-11)
-		ret6 := matchArg(tcMock6, args)
-		assert.True(t, ret6 == nil)
-	})
+func (m *TrafficShapingControllerMock) ExtractArgs(ctx *base.EntryContext) []interface{} {
+	_ = m.Called()
+	ret := []interface{}{ctx.Input.Args[m.BoundParamIndex()]}
+	return ret
 }

--- a/core/hotspot/traffic_shaping.go
+++ b/core/hotspot/traffic_shaping.go
@@ -165,7 +165,7 @@ func (c *baseTrafficShapingController) ExtractArgs(ctx *base.EntryContext) []int
 	if c == nil {
 		return nil
 	}
-	args := make([]interface{}, 0)
+	args := make([]interface{}, 0, len(ctx.Input.Args)+len(ctx.Input.Attachments))
 
 	indexArg := c.extractArgs(ctx)
 	if indexArg != nil {
@@ -204,13 +204,14 @@ func (c *baseTrafficShapingController) extractAttachmentArgs(ctx *base.EntryCont
 
 	if attachments == nil {
 		if logging.DebugEnabled() {
-			logging.Debug("[extractAttachment] The attachments of ctx is nil",
+			logging.Debug("[paramKey] The attachments of ctx is nil",
 				"args", attachments, "paramIndex", c.paramKey)
 		}
+		return nil
 	}
 	if c.paramKey == "" {
 		if logging.DebugEnabled() {
-			logging.Debug("[extractAttachment] The param key is nil",
+			logging.Debug("[paramKey] The param key is nil",
 				"args", attachments, "paramIndex", c.paramKey)
 		}
 		return nil
@@ -218,7 +219,7 @@ func (c *baseTrafficShapingController) extractAttachmentArgs(ctx *base.EntryCont
 	arg, ok := attachments[c.paramKey]
 	if !ok {
 		if logging.DebugEnabled() {
-			logging.Debug("[extractAttachment] extracted data does not exist",
+			logging.Debug("[paramKey] extracted data does not exist",
 				"args", attachments, "paramIndex", c.paramKey)
 		}
 	}

--- a/example/hotspot_param_flow/concurrency/hotspot_params_concurrency_example.go
+++ b/example/hotspot_param_flow/concurrency/hotspot_params_concurrency_example.go
@@ -35,6 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	testKey := "testKey"
 
 	// the max concurrency is 8
 	_, err = hotspot.LoadRules([]*hotspot.Rule{
@@ -42,6 +43,7 @@ func main() {
 			Resource:      "abc",
 			MetricType:    hotspot.Concurrency,
 			ParamIndex:    0,
+			ParamKey:      testKey,
 			Threshold:     8,
 			DurationInSec: 0,
 		},
@@ -79,7 +81,12 @@ func main() {
 	}
 
 	for {
-		e, b := sentinel.Entry("abc", sentinel.WithArgs(false, uint32(9)))
+		e, b := sentinel.Entry("abc",
+			sentinel.WithArgs(false, uint32(9),
+				sentinel.WithAttachments(map[interface{}]interface{}{
+					testKey: rand.Uint64() % 10,
+				}),
+			))
 		if b != nil {
 			// Blocked. We could get the block reason from the BlockError.
 			time.Sleep(time.Duration(rand.Uint64()%10) * time.Millisecond)

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.20.11
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/multierr v1.5.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
@@ -60,6 +61,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
热点参数规则中，增加ParamKey配合context attachments map ,方便快速从大量的键值对中指定需要热点限流的值. (alibaba#355)

### Describe what this PR does / why we need it
方便热点限流规则中，指定热点参数。
比如把系统参数、header中标定参数、业务参数，数据很多，不同业务需要的参数也不相同，加入把全部数据放入ctx.attachments 这样在规则中指定特点的key，很方便。

### Does this pull request fix one issue?
本次pr 已经增加ParamKey, 并且修改了对应的单元测试和example.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
规则增加ParamKey；
trafficShaper 也对应实现extractArg 接口，可以与已有的paramIndex 一起方便指定热点参数。

### Describe how to verify it
单元测试和example 中均验证过了

### Special notes for reviews
ParamKey 可以考虑变成[]string ，这样使用者除了指定单个参数外，还可以灵活的指定热点的规则。
例如ParamKey=[]string{"uid","merchant_id"} 这样可以让uid和merchant_id 作为联合参数作为热点。