### PR TITLE
fix concurrency isolation control bug

### DIFF
--- a/core/base/stat.go
+++ b/core/base/stat.go
@@ -100,6 +100,11 @@ type ConcurrencyStat interface {
 	DecreaseConcurrency()
 }
 
+type PreConcurrencyStat interface {
+	IncreasePreConcurrency() int32
+	TryDecreasePreConcurrency()
+}
+
 // StatNode holds real-time statistics for resources.
 type StatNode interface {
 	MetricItemRetriever
@@ -107,6 +112,7 @@ type StatNode interface {
 	ReadStat
 	WriteStat
 	ConcurrencyStat
+	PreConcurrencyStat
 
 	// GenerateReadStat generates the readonly metric statistic based on resource level global statistic
 	// If parameters, sampleCount and intervalInMs, are not suitable for resource level global statistic, return (nil, error)

--- a/core/base/stat_test.go
+++ b/core/base/stat_test.go
@@ -79,6 +79,14 @@ func (m *StatNodeMock) DecreaseConcurrency() {
 	return
 }
 
+func (m *StatNodeMock) IncreasePreConcurrency() int32 {
+	return 0
+}
+
+func (m *StatNodeMock) TryDecreasePreConcurrency() {
+	return
+}
+
 func (m *StatNodeMock) GenerateReadStat(sampleCount uint32, intervalInMs uint32) (ReadStat, error) {
 	args := m.Called(sampleCount, intervalInMs)
 	return args.Get(0).(ReadStat), args.Error(1)

--- a/core/isolation/slot.go
+++ b/core/isolation/slot.go
@@ -65,7 +65,8 @@ func checkPass(ctx *base.EntryContext) (bool, *Rule, uint32) {
 				curCount = 0
 				logging.Error(errors.New("negative concurrency"), "Negative concurrency in isolation.checkPass()", "rule", rule)
 			}
-			if curCount+batchCount > threshold {
+			preCurCount := uint32(statNode.IncreasePreConcurrency()) - 1
+			if curCount+batchCount+preCurCount > threshold {
 				return false, rule, curCount
 			}
 		}

--- a/core/stat/base_node.go
+++ b/core/stat/base_node.go
@@ -26,7 +26,8 @@ type BaseStatNode struct {
 	sampleCount uint32
 	intervalMs  uint32
 
-	concurrency int32
+	concurrency    int32
+	preConcurrency int32
 
 	arr    *sbase.BucketLeapArray
 	metric *sbase.SlidingWindowMetric
@@ -98,6 +99,16 @@ func (n *BaseStatNode) IncreaseConcurrency() {
 
 func (n *BaseStatNode) DecreaseConcurrency() {
 	atomic.AddInt32(&(n.concurrency), -1)
+}
+
+func (n *BaseStatNode) IncreasePreConcurrency() int32 {
+	return atomic.AddInt32(&(n.preConcurrency), 1)
+}
+
+func (n *BaseStatNode) TryDecreasePreConcurrency() {
+	if atomic.LoadInt32(&(n.preConcurrency)) > 0 {
+		atomic.AddInt32(&(n.preConcurrency), -1)
+	}
 }
 
 func (n *BaseStatNode) GenerateReadStat(sampleCount uint32, intervalInMs uint32) (base.ReadStat, error) {

--- a/core/stat/stat_slot.go
+++ b/core/stat/stat_slot.go
@@ -39,6 +39,7 @@ func (s *Slot) OnEntryPassed(ctx *base.EntryContext) {
 	if ctx.Resource.FlowType() == base.Inbound {
 		s.recordPassFor(InboundNode(), ctx.Input.BatchCount)
 	}
+	ctx.StatNode.TryDecreasePreConcurrency()
 }
 
 func (s *Slot) OnEntryBlocked(ctx *base.EntryContext, blockError *base.BlockError) {
@@ -46,6 +47,7 @@ func (s *Slot) OnEntryBlocked(ctx *base.EntryContext, blockError *base.BlockErro
 	if ctx.Resource.FlowType() == base.Inbound {
 		s.recordBlockFor(InboundNode(), ctx.Input.BatchCount)
 	}
+	ctx.StatNode.TryDecreasePreConcurrency()
 }
 
 func (s *Slot) OnCompleted(ctx *base.EntryContext) {

--- a/tests/core/isolation/isolation_test.go
+++ b/tests/core/isolation/isolation_test.go
@@ -1,0 +1,55 @@
+package isolation
+
+import (
+	sentinel "github.com/alibaba/sentinel-golang/api"
+	"github.com/alibaba/sentinel-golang/core/circuitbreaker"
+	"github.com/alibaba/sentinel-golang/core/isolation"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConcurrency(t *testing.T) {
+	var (
+		resource      = "test"
+		maxConcurrent = 20000
+		sleepChan     = make(chan struct{})
+		passNum       = int32(0) // number of goroutine successfully passed
+		isContinue    = true
+	)
+	_, _ = isolation.LoadRules([]*isolation.Rule{
+		{
+			Resource:   resource,
+			MetricType: isolation.Concurrency,
+			Threshold:  uint32(maxConcurrent),
+		},
+	})
+	_, _ = circuitbreaker.LoadRules([]*circuitbreaker.Rule{
+		{
+			Resource:         resource,
+			Strategy:         circuitbreaker.ErrorRatio,
+			RetryTimeoutMs:   uint32(5000),
+			StatIntervalMs:   5000,
+			Threshold:        0.5,
+		},
+	})
+	for isContinue {
+		go func() {
+			entry, err := sentinel.Entry(resource)
+			if err != nil {
+				isContinue = false
+			}else {
+				defer entry.Exit()
+				// when passing, passNum++
+				atomic.AddInt32(&passNum, 1)
+				// suppose to block here
+				<-sleepChan
+			}
+		}()
+	}
+	time.Sleep(1 * time.Second)
+	if passNum != int32(maxConcurrent) {
+		t.Fatalf("current concurrent is %d, set max concurrent is %d, this is not equal", passNum, maxConcurrent)
+	}
+	t.Logf("current concurrent is %d, set max concurrent is %d, this is equal", passNum, maxConcurrent)
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

[[BUG\] The actual maximum concurrency may exceed the threshold of concurrency isolation control · Issue #394 · alibaba/sentinel-golang (github.com)](https://github.com/alibaba/sentinel-golang/issues/394)


### Does this pull request fix one issue?

Fixes #394

### Describe how you did it

In the previous version, for the "concurrency" field of the "BaseStatNode" struct , reading and writing here are not at the same time. Will miss a certain number of concurrency statistics, I added a "preConcurrency" field,  It is used to record these unrecorded concurrent numbers.

At the "execute rule based checking slot", Only when read "concurrency", will Increase the "preConcurrency"

At the "execute statistic slot", try to Decrease the "preConcurrency" 

### Describe how to verify it

I added the unit test mentioned before and it can now pass.


### Special notes for reviews

I don't think so.