### PR TITLE
Add sampleCount zero checking in NewLeapArray func

### DIFF
--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -159,7 +159,7 @@ type LeapArray struct {
 }
 
 func NewLeapArray(sampleCount uint32, intervalInMs uint32, generator BucketGenerator) (*LeapArray, error) {
-	if intervalInMs%sampleCount != 0 {
+	if sampleCount == 0 || intervalInMs%sampleCount != 0 {
 		return nil, errors.Errorf("Invalid parameters, intervalInMs is %d, sampleCount is %d", intervalInMs, sampleCount)
 	}
 	if generator == nil {

--- a/core/stat/base/leap_array_test.go
+++ b/core/stat/base/leap_array_test.go
@@ -297,4 +297,9 @@ func TestNewLeapArray(t *testing.T) {
 		assert.Nil(t, leapArray)
 		assert.Error(t, err, "Invalid parameters, intervalInMs is 10000, sampleCount is 30")
 	})
+	t.Run("TestNewLeapArray_Invalid_Parameters_sampleCount0", func(t *testing.T) {
+		leapArray, err := NewLeapArray(0, IntervalInMs, nil)
+		assert.Nil(t, leapArray)
+		assert.Error(t, err, "Invalid parameters, intervalInMs is 10000, sampleCount is 0")
+	})
 }


### PR DESCRIPTION
first param of function ` NewLeapArray`   can  not  be  zero.  Or  it  will  cause panic  `runtime error: divide by zero`