### PR TITLE
atomicBucketWrapArray supports 32-bit os

### DIFF
--- a/core/stat/base/leap_array.go
+++ b/core/stat/base/leap_array.go
@@ -26,10 +26,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	PtrSize = int(8)
-)
-
 // BucketWrap represent a slot to record metrics
 // In order to reduce the usage of memory, BucketWrap don't hold length of BucketWrap
 // The length of BucketWrap could be seen in LeapArray.
@@ -115,7 +111,7 @@ func (aa *AtomicBucketWrapArray) elementOffset(idx int) (unsafe.Pointer, bool) {
 		return nil, false
 	}
 	basePtr := aa.base
-	return unsafe.Pointer(uintptr(basePtr) + uintptr(idx*PtrSize)), true
+	return unsafe.Pointer(uintptr(basePtr) + uintptr(idx)*unsafe.Sizeof(basePtr)), true
 }
 
 func (aa *AtomicBucketWrapArray) get(idx int) *BucketWrap {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
On 32-bit os, pointers occupy 4 bytes, currently 8 bytes by default, resulting in some empty buckets

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews