### PR TITLE
add a metric to monitor queued requests 

### DIFF
--- a/core/flow/slot.go
+++ b/core/flow/slot.go
@@ -67,7 +67,7 @@ func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 		}
 		if r.Status() == base.ResultStatusShouldWait {
 			if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
-				flowWaitCount.Add(1, ctx.Resource.Name())
+				flowWaitCount.Add(float64(ctx.Input.BatchCount), ctx.Resource.Name())
 				// Handle waiting action.
 				util.Sleep(nanosToWait)
 			}

--- a/core/flow/slot.go
+++ b/core/flow/slot.go
@@ -17,6 +17,7 @@ package flow
 import (
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/core/stat"
+	metric_exporter "github.com/alibaba/sentinel-golang/exporter/metric"
 	"github.com/alibaba/sentinel-golang/logging"
 	"github.com/alibaba/sentinel-golang/util"
 	"github.com/pkg/errors"
@@ -27,8 +28,16 @@ const (
 )
 
 var (
-	DefaultSlot = &Slot{}
+	DefaultSlot   = &Slot{}
+	flowWaitCount = metric_exporter.NewCounter(
+		"flow_wait_total",
+		"Flow wait count",
+		[]string{"resource"})
 )
+
+func init() {
+	metric_exporter.Register(flowWaitCount)
+}
 
 type Slot struct {
 }
@@ -58,6 +67,7 @@ func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 		}
 		if r.Status() == base.ResultStatusShouldWait {
 			if nanosToWait := r.NanosToWait(); nanosToWait > 0 {
+				flowWaitCount.Add(1, ctx.Resource.Name())
 				// Handle waiting action.
 				util.Sleep(nanosToWait)
 			}

--- a/exporter/metric/empty_exporter.go
+++ b/exporter/metric/empty_exporter.go
@@ -1,0 +1,1 @@
+package metric

--- a/exporter/metric/empty_exporter.go
+++ b/exporter/metric/empty_exporter.go
@@ -1,1 +1,65 @@
 package metric
+
+import "net/http"
+
+type EmptyExporter struct {
+}
+
+func (e *EmptyExporter) HTTPHandler() http.Handler {
+	return nil
+}
+
+type emptyMetric struct {
+}
+
+func (e emptyMetric) Register() error {
+	return nil
+}
+
+func (e emptyMetric) Unregister() bool {
+	return false
+}
+
+func (e emptyMetric) Reset() {
+	return
+}
+
+func newEmptyExporter() *EmptyExporter {
+	return &EmptyExporter{}
+}
+
+type emptyCounter struct {
+	emptyMetric
+}
+
+func (e emptyCounter) Add(value float64, labelValues ...string) {
+	return
+}
+
+func (e *EmptyExporter) NewCounter(name, desc string, labelNames []string) Counter {
+	return emptyCounter{}
+}
+
+type emptyGauge struct {
+	emptyMetric
+}
+
+func (e emptyGauge) Set(value float64, labelValues ...string) {
+	return
+}
+
+func (e *EmptyExporter) NewGauge(name, desc string, labelNames []string) Gauge {
+	return &emptyGauge{}
+}
+
+type emptyHistogram struct {
+	emptyMetric
+}
+
+func (e emptyHistogram) Observe(value float64, labelValues ...string) {
+	return
+}
+
+func (e *EmptyExporter) NewHistogram(name, desc string, buckets []float64, labelNames []string) Histogram {
+	return &emptyHistogram{}
+}

--- a/exporter/metric/exporter.go
+++ b/exporter/metric/exporter.go
@@ -33,9 +33,9 @@ var (
 )
 
 func init() {
-	if config.MetricExportHTTPAddr() != ""{
+	if config.MetricExportHTTPAddr() != "" {
 		exporter = newPrometheusExporter()
-	}else {
+	} else {
 		exporter = newEmptyExporter()
 	}
 

--- a/exporter/metric/exporter.go
+++ b/exporter/metric/exporter.go
@@ -33,7 +33,11 @@ var (
 )
 
 func init() {
-	exporter = newPrometheusExporter()
+	if config.MetricExportHTTPAddr() != ""{
+		exporter = newPrometheusExporter()
+	}else {
+		exporter = newEmptyExporter()
+	}
 
 	host, _ = os.Hostname()
 	if host == "" {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

In addition to monitoring resource passage and blocking, I think I need a metric exporter to show the status of my resource queued requests



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1  add a metric to monitor queued requests 
2   add empty metric exporter because if we don’t configure metric http address, we don’t need to instantiate promethues exporter
### Describe how to verify it

### Special notes for reviews
@gorexlv 