### PR TITLE
feat: add timeout counter metric

### DIFF
--- a/core/base/metric_item.go
+++ b/core/base/metric_item.go
@@ -37,6 +37,7 @@ type MetricItem struct {
 	ErrorQps             uint64
 	AvgRt                uint64
 	OccupiedPassQps      uint64
+	TimeoutCounter       uint64
 	Concurrency          uint32
 	SecondMaxConcurrency uint32
 }

--- a/core/base/stat.go
+++ b/core/base/stat.go
@@ -37,6 +37,8 @@ const (
 	MetricEventRt
 	// Specific for verifying mode
 	MetricEventMonitorBlock
+	// timeout counter
+	MetricEventTimeout
 	// hack for the number of event
 	MetricEventTotal
 )

--- a/core/stat/base/metric_bucket_test.go
+++ b/core/stat/base/metric_bucket_test.go
@@ -27,7 +27,7 @@ func Test_metricBucket_MemSize(t *testing.T) {
 	mb := NewMetricBucket()
 	t.Log("mb:", mb)
 	size := unsafe.Sizeof(*mb)
-	if size != 64 {
+	if size != 72 {
 		t.Error("unexpect memory size of MetricBucket")
 	}
 }

--- a/core/stat/base/sliding_window_metric.go
+++ b/core/stat/base/sliding_window_metric.go
@@ -243,6 +243,7 @@ func (m *SlidingWindowMetric) metricItemFromBucket(w *BucketWrap) *base.MetricIt
 		BlockQps:        uint64(mb.Get(base.MetricEventBlock)),
 		MonitorBlockQps: uint64(mb.Get(base.MetricEventMonitorBlock)),
 		ErrorQps:        uint64(mb.Get(base.MetricEventError)),
+		TimeoutCounter:  uint64(mb.Get(base.MetricEventTimeout)),
 		CompleteQps:     uint64(completeQps),
 		Timestamp:       w.BucketStart,
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add a new independent metric for timeout, it records how many requests was failed due to timeout, this data is useful to improve the precision of concurrency amount statistics when a large number of requests timeout

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews