### PR TITLE
[fix:#423] add CI for 32-bit environment

### DIFF
--- a/.github/workflows/go-32bit.yml
+++ b/.github/workflows/go-32bit.yml
@@ -1,0 +1,83 @@
+name: CI for 32-bit
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: "*"
+
+jobs:
+
+  build:
+    name: ${{ matrix.os }} - Go ${{ matrix.go_version }}
+    runs-on: ubuntu-latest
+    strategy:
+     # If you want to matrix build , you can append the following list.
+      matrix:
+        go_version:
+          - 1.13
+          - 1.14
+        os:
+          - ubuntu-latest
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go_version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go_version }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Cache build dependence
+      uses: actions/cache@v2
+      with:
+        # Cache
+        path: ~/go/pkg/mod
+        # Cache key
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
+        restore-keys: ${{ runner.os }}-go-
+
+    - name: Install goimports
+      run: go get golang.org/x/tools/cmd/goimports
+
+    - name: Install go ci lint
+      # 1. download the install.sh file of golangci-lint
+      # 2. replace the arch name which will be joined as the golangci-lint resource file name will download in install.sh
+      #    the golangci-lint resource file is in the tag which has tagged and will do really install action
+      # 3. execute install.sh to do really install action
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sed 's/ARCH=$(uname_arch)/ARCH=386/g' | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+
+    - name: Run Linter
+      run: golangci-lint run --timeout=10m -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
+
+    - name: Test
+      run: |
+        diff -u <(echo -n) <(gofmt -d -s .)
+        diff -u <(echo -n) <(goimports -d .)
+        go test -v -race ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ./pkg/datasource/consul
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../etcdv3
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../k8s
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../nacos
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../apollo
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../../adapters/echo
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../gear
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../gin
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../grpc
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+        cd ../micro
+        go test -race -count=1 ./... -coverprofile=coverage.txt -covermode=atomic
+    - name: Coverage
+      run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

[fix:#423] add CI for 32-bit environment

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #423 

### Describe how you did it
1、add a go-32bit.yml in directory .github/workflows
2、changed the install file of golangci-lint in step of the go-32bit.yml where install the golangci-lint
----------中文分割线----------
1、在 .github/workflows 目录下添加一个 go-32bit.yml 的 CI文件
2、在go-32bit.yml的step步骤中改变 安装 golangci-lint 的执行脚本，从而下载对应的安装版本


In the default version go.yml, shortcut pic of downloading golangci-lint like following:
----------中文分割线----------
在原有的 go.yml 中，golangci-lint 的下载版本如下图中所示:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/43714056/183407087-579c8372-aa5a-4460-869a-a2fb3b293dd2.png">
default download param 'os' and 'arch' is comes from the runer-on OS in the go.yml, we can see the source in https://github.com/golangci/golangci-lint/blob/v1.48.0/install.sh in line 373、374、401、403
----------中文分割线----------
默认的下载参数 os 和 arch 是从go.yml中定义的 runner-os 的操作系统中获取的，在 golangci-lint  的源码的 373、374、401、403 中我们就能看到
<img width="941" alt="download" src="https://user-images.githubusercontent.com/43714056/183407430-7962d9bd-c12f-4cee-a839-0cb59c3309fd.png">


But，there is no param to define target os and arch, so my idea is  replacing the arch name which will be joined as the golangci-lint resource file name will download in install.sh.  by execute the command ` sed 's/ARCH=$(uname_arch)/ARCH=386/g'' `, and then download the installation file in
the golangci-lint resource file is in the tag which has tagged and will do really install action
----------中文分割线----------
但是，在 golangci-lint 官方提供的安装脚本中，并没有提供 指定 目标os 和目标arch的参数，所以我的做法是在 下载的install.sh文件中，将用来拼接安装包下载地址的arch参数平台通过  ` sed 's/ARCH=$(uname_arch)/ARCH=386/g'' ` 命令修改为 386(即32位品台) 从而得到要安装的 golangci-lint  的对应品台的版本，然后执行 安装工作
<img width="1474" alt="image" src="https://user-images.githubusercontent.com/43714056/183410231-d5dadba2-1a52-4430-b513-b0c1ef300c60.png">
following is install process of golangci-lint in the sourcecode
----------中文分割线----------
golangci-lint 源码中的安装过程如下:
<img width="661" alt="execute" src="https://user-images.githubusercontent.com/43714056/183412814-fe679868-1512-4b8c-a1eb-6fdc5414dd29.png">


### Describe how to verify it

in the logs of go-32bit.yml workflow, we can see the arch is changed in the log info like:
----------中文分割线----------
在 go-32bit.yml 的执行日志中，我们可以看到 arch 已经修改成功
<img width="826" alt="image" src="https://user-images.githubusercontent.com/43714056/183410785-915fd98c-a7c2-4b9a-98b7-f3de7d54f27b.png">


### Special notes for reviews
As we see, golangci-lint is not support defining the os and arch in current version， if we want to use it more convenient, we can contribute in the project of https://github.com/golangci/golangci-lint.
----------中文分割线----------
正如我们所见， golangci-lint 当前版本不支持自定义 os 和 arch,如果我们想要更方便的使用它,我们可以在 https://github.com/golangci/golangci-lint 中贡献代码。





