### PR TITLE
feat:  add biz-defined error counter

### DIFF
--- a/core/base/metric_item.go
+++ b/core/base/metric_item.go
@@ -39,6 +39,7 @@ type MetricItem struct {
 	OccupiedPassQps      uint64
 	TimeoutCounter       uint64
 	DegradeCounter       uint64
+	BizErrorCounter      uint64
 	Concurrency          uint32
 	SecondMaxConcurrency uint32
 }

--- a/core/base/stat.go
+++ b/core/base/stat.go
@@ -41,6 +41,8 @@ const (
 	MetricEventTimeout
 	// degrade counter
 	MetricEventDegrade
+	// business-defined error
+	MetricEventBizError
 	// hack for the number of event
 	MetricEventTotal
 )
@@ -147,7 +149,7 @@ func CheckValidityForReuseStatistic(sampleCount, intervalInMs uint32, parentSamp
 	}
 	parentBucketLengthInMs := parentIntervalInMs / parentSampleCount
 
-	//SlidingWindowMetric's intervalInMs is not divisible by BucketLeapArray's intervalInMs
+	// SlidingWindowMetric's intervalInMs is not divisible by BucketLeapArray's intervalInMs
 	if parentIntervalInMs%intervalInMs != 0 {
 		return GlobalStatisticNonReusableError
 	}

--- a/core/stat/base/metric_bucket_test.go
+++ b/core/stat/base/metric_bucket_test.go
@@ -27,7 +27,7 @@ func Test_metricBucket_MemSize(t *testing.T) {
 	mb := NewMetricBucket()
 	t.Log("mb:", mb)
 	size := unsafe.Sizeof(*mb)
-	if size != 80 {
+	if size != 88 {
 		t.Error("unexpect memory size of MetricBucket")
 	}
 }

--- a/core/stat/base/sliding_window_metric.go
+++ b/core/stat/base/sliding_window_metric.go
@@ -218,6 +218,7 @@ func (m *SlidingWindowMetric) metricItemFromBuckets(ts uint64, ws []*BucketWrap)
 		item.MonitorBlockQps += uint64(mb.Get(base.MetricEventMonitorBlock))
 		item.TimeoutCounter += uint64(mb.Get(base.MetricEventTimeout))
 		item.DegradeCounter += uint64(mb.Get(base.MetricEventDegrade))
+		item.BizErrorCounter += uint64(mb.Get(base.MetricEventBizError))
 		allRt += mb.Get(base.MetricEventRt)
 	}
 	if item.CompleteQps > 0 {
@@ -247,6 +248,7 @@ func (m *SlidingWindowMetric) metricItemFromBucket(w *BucketWrap) *base.MetricIt
 		ErrorQps:        uint64(mb.Get(base.MetricEventError)),
 		TimeoutCounter:  uint64(mb.Get(base.MetricEventTimeout)),
 		DegradeCounter:  uint64(mb.Get(base.MetricEventDegrade)),
+		BizErrorCounter: uint64(mb.Get(base.MetricEventBizError)),
 		CompleteQps:     uint64(completeQps),
 		Timestamp:       w.BucketStart,
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

原来的MetricEvent中包含了MetricEventError用于记录错误，我们之前也一直用这个Metric记录所有的错误，但现在业务希望将一些自定义错误和RPC调用错误区别开，例如RPC请求成功了但是返回了特定的响应值或者RT超过特定阈值定义为业务错误，而RPC调用失败/超时等定义为RPC错误。


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews