### PR TITLE
fix unsupported type map[interface{}]int64 via x.SpecificItems

### DIFF
--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -64,44 +64,82 @@ func (t MetricType) String() string {
 // Rule represents the hotspot(frequent) parameter flow control rule
 type Rule struct {
 	// ID is the unique id
-	ID string `json:"id,omitempty"`
+	ID string `json:"Id,omitempty"`
 	// Resource is the resource name
-	Resource string `json:"resource"`
+	Resource string `json:"Resource"`
 	// MetricType indicates the metric type for checking logic.
 	// For Concurrency metric, hotspot module will check the each hot parameter's concurrency,
 	//		if concurrency exceeds the Threshold, reject the traffic directly.
 	// For QPS metric, hotspot module will check the each hot parameter's QPS,
 	//		the ControlBehavior decides the behavior of traffic shaping controller
-	MetricType MetricType `json:"metricType"`
+	MetricType MetricType `json:"MetricType"`
 	// ControlBehavior indicates the traffic shaping behaviour.
 	// ControlBehavior only takes effect when MetricType is QPS
-	ControlBehavior ControlBehavior `json:"controlBehavior"`
+	ControlBehavior ControlBehavior `json:"ControlBehavior"`
 	// ParamIndex is the index in context arguments slice.
 	// if ParamIndex is great than or equals to zero, ParamIndex means the <ParamIndex>-th parameter
 	// if ParamIndex is the negative, ParamIndex means the reversed <ParamIndex>-th parameter
-	ParamIndex int `json:"paramIndex"`
+	ParamIndex int `json:"ParamIndex"`
 	// ParamKey is the key in EntryContext.Input.Attachments map.
 	// ParamKey can be used as a supplement to ParamIndex to facilitate rules to quickly obtain parameter from a large number of parameters
 	// ParamKey is mutually exclusive with ParamIndex, ParamKey has the higher priority than ParamIndex
-	ParamKey string `json:"paramKey"`
+	ParamKey string `json:"ParamKey"`
 	// Threshold is the threshold to trigger rejection
-	Threshold int64 `json:"threshold"`
+	Threshold int64 `json:"Threshold"`
 	// MaxQueueingTimeMs only takes effect when ControlBehavior is Throttling and MetricType is QPS
-	MaxQueueingTimeMs int64 `json:"maxQueueingTimeMs"`
+	MaxQueueingTimeMs int64 `json:"MaxQueueingTimeMs"`
 	// BurstCount is the silent count
 	// BurstCount only takes effect when ControlBehavior is Reject and MetricType is QPS
-	BurstCount int64 `json:"burstCount"`
+	BurstCount int64 `json:"BurstCount"`
 	// DurationInSec is the time interval in statistic
 	// DurationInSec only takes effect when MetricType is QPS
-	DurationInSec int64 `json:"durationInSec"`
+	DurationInSec int64 `json:"DurationInSec"`
 	// ParamsMaxCapacity is the max capacity of cache statistic
-	ParamsMaxCapacity int64 `json:"paramsMaxCapacity"`
+	ParamsMaxCapacity int64 `json:"ParamsMaxCapacity"`
 	// SpecificItems indicates the special threshold for specific value
-	SpecificItems map[interface{}]int64 `json:"specificItems"`
+	SpecificItems map[interface{}]int64
+}
+
+type SpecificItem struct {
+	Key   string `json:"key"`
+	Value int64  `json:"value"`
+}
+
+func (t MetricType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+func (c ControlBehavior) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
+}
+
+// Store the key-value pairs in specificItems in a temporary slice
+func convertSpecificItems(specificItems map[interface{}]int64) []*SpecificItem {
+	items := make([]*SpecificItem, 0, len(specificItems))
+	for k, v := range specificItems {
+		key, ok := k.(string)
+		if !ok {
+			key = fmt.Sprintf("%v", k)
+		}
+		item := &SpecificItem{
+			Key:   key,
+			Value: v,
+		}
+		items = append(items, item)
+	}
+	return items
 }
 
 func (r *Rule) String() string {
-	b, err := json.Marshal(r)
+	type tempRule Rule
+	specificItems := convertSpecificItems(r.SpecificItems)
+
+	b, err := json.Marshal(&struct {
+		*tempRule
+		SpecificItems []*SpecificItem `json:"SpecificItems"`
+	}{
+		tempRule:      (*tempRule)(r),
+		SpecificItems: specificItems,
+	})
 	if err != nil {
 		// Return the fallback string
 		return fmt.Sprintf("{Id:%s, Resource:%s, MetricType:%+v, ControlBehavior:%+v, ParamIndex:%d, ParamKey:%s, Threshold:%d, MaxQueueingTimeMs:%d, BurstCount:%d, DurationInSec:%d, ParamsMaxCapacity:%d, SpecificItems:%+v}",
@@ -109,6 +147,7 @@ func (r *Rule) String() string {
 	}
 	return string(b)
 }
+
 func (r *Rule) ResourceName() string {
 	return r.Resource
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix hotspot.Rule marshal unsupported type map[interface{}]int64 via x.SpecificItems

### Does this pull request fix one issue?
fix #505 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
利用临时变量结构体specificItems ，使用convertSpecificItems 函数将 map[interface{}]int64 类型的 specificItems 转换为 []*SpecificItem 类型的切片，其中 SpecificItem 结构体，包含了 Key 和 Value 两个字段用于描述具体的map[interface{}]int64项。为了保证临时结构体依然按照Rule的tag在序列化时输出，实现MetricType，与ControlBehavior的MarshalJSON()
方法使其序列化格式正确

 
### Describe how to verify it


### Special notes for reviews

改变后对于原rule_test.go中的Test_Rule_String方法 最后的SpecificItem，
assert.True(t, fmt.Sprintf("%+v", []*Rule{r}) == "[{Id:abc, Resource:abc, MetricType:Concurrency, ControlBehavior:Reject, ParamIndex:0, ParamKey:key, Threshold:110, MaxQueueingTimeMs:5, BurstCount:10, DurationInSec:1, ParamsMaxCapacity:10000,             SpecificItems:map[1123:3 sss:1]}]")


[{"Id":"abc","Resource":"abc","MetricType":"Concurrency","ControlBehavior":"Reject","ParamIndex":0,"ParamKey":"key","Threshold":110,"MaxQueueingTimeMs":5,"BurstCount":10,"DurationInSec":1,"ParamsMaxCapacity":10000 
  ,          "SpecificItems":[{"key":"sss","value":1},{"key":"1123","value":3}]}]
从 map变为slice,这里的一定要保持原test的map输出吗，请您指出我的错误，如果给您带来麻烦我很抱歉