### PR TITLE
Upgrade the latest Metric log file name to a fixed format

### DIFF
--- a/core/log/metric/common.go
+++ b/core/log/metric/common.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/util"
 )
 
 const (
@@ -71,6 +72,27 @@ func FormMetricFileName(serviceName string, withPid bool) string {
 // Generate the metric index filename from the metric log filename.
 func formMetricIdxFileName(metricFilename string) string {
 	return metricFilename + MetricIdxSuffix
+}
+
+func getLastFileSuffixIndex(list []string) uint32 {
+	if len(list) == 0 {
+		return 0
+	}
+	last := list[len(list)-1]
+	var n uint32 = 0
+	items := strings.Split(last, ".")
+	if len(items) > 0 {
+		v, err := strconv.ParseUint(items[len(items)-1], 10, 32)
+		if err == nil {
+			n = uint32(v)
+		}
+	}
+	return n
+}
+func doRotateBaseAndIndexFile(fileName, pattern string, index int) {
+	newFileName := fileName + "." + pattern + "." + strconv.Itoa(index)
+	util.FileRename(fileName, newFileName)
+	util.FileRename(formMetricIdxFileName(fileName), formMetricIdxFileName(newFileName))
 }
 
 func filenameMatches(filename, baseFilename string) bool {

--- a/core/log/metric/writer_test.go
+++ b/core/log/metric/writer_test.go
@@ -1,0 +1,334 @@
+package metric
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/alibaba/sentinel-golang/util"
+)
+
+func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
+	_, offset := util.Now().Zone()
+	fmt.Println("old offset:", offset)
+	type fields struct {
+		baseDir           string
+		baseFilename      string
+		maxSingleSize     uint64
+		maxFileAmount     uint32
+		timezoneOffsetSec int64
+		latestOpSec       int64
+		curMetricFile     *os.File
+		curMetricIdxFile  *os.File
+		metricOut         *bufio.Writer
+		idxOut            *bufio.Writer
+		mux               *sync.RWMutex
+	}
+	type args struct {
+		time   uint64
+		before func()
+		file   func()
+		clear  func()
+	}
+	baseDir := "/tmp/logs/"
+	metricsLog := "test-metrics.log"
+	perm := 0755
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "no any file in baseDir,create new file",
+			fields: fields{
+				baseDir:           baseDir,
+				baseFilename:      metricsLog,
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: 0,
+				latestOpSec:       0,
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).UnixMilli()),
+				before: func() {
+					_ = os.RemoveAll(baseDir)
+					_ = os.MkdirAll(baseDir, os.FileMode(perm))
+				},
+				clear: func() {
+					_ = os.RemoveAll(baseDir)
+				},
+			},
+			want:    baseDir + metricsLog,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "have today date file in baseDir,rotate it and create new file",
+			fields: fields{
+				baseDir:           baseDir,
+				baseFilename:      metricsLog,
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       time.Date(2023, 12, 15, 10, 0, 0, 0, time.Local).Unix(),
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).UnixMilli()),
+				before: func() {
+					_ = os.RemoveAll(baseDir)
+					_ = os.MkdirAll(baseDir, os.FileMode(perm))
+				},
+				file: func() {
+					_, _ = os.Create(baseDir + metricsLog)
+				},
+				clear: func() {
+					_ = os.RemoveAll(baseDir)
+				},
+			},
+			want:    baseDir + metricsLog,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "have yesterday date file in baseDir,rotate it to yesterday date file and create new today date file",
+			fields: fields{
+				baseDir:           baseDir,
+				baseFilename:      metricsLog,
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       time.Date(2023, 12, 14, 23, 59, 59, 0, time.Local).Unix(), //昨日
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).UnixMilli()),
+				before: func() {
+					_ = os.RemoveAll(baseDir)
+					_ = os.MkdirAll(baseDir, os.FileMode(perm))
+				},
+				file: func() {
+					yesterday := time.Date(2023, 12, 14, 23, 59, 59, 0, time.Local).UnixMilli()
+					dateStr := util.FormatDate(uint64(yesterday))
+					_, _ = os.Create(baseDir + metricsLog)
+					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
+				},
+				clear: func() {
+					_ = os.RemoveAll(baseDir)
+				},
+			},
+			want:    baseDir + metricsLog,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "have yesterday archive file and today date file in baseDir,rotate it and create new file",
+			fields: fields{
+				baseDir:           baseDir,
+				baseFilename:      metricsLog,
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       time.Date(2023, 12, 15, 10, 0, 0, 0, time.Local).Unix(),
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).UnixMilli()),
+				before: func() {
+					_ = os.RemoveAll(baseDir)
+					_ = os.MkdirAll(baseDir, os.FileMode(perm))
+				},
+				file: func() {
+					yesterday := time.Now().Add(-24 * time.Hour).UnixMilli()
+					dateStr := util.FormatDate(uint64(yesterday))
+					_, _ = os.Create(baseDir + metricsLog)
+					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
+				},
+				clear: func() {
+					_ = os.RemoveAll(baseDir)
+				},
+			},
+			want:    baseDir + metricsLog,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "have yesterday archive file and today archive file and today date file in baseDir,rotate it and create new file",
+			fields: fields{
+				baseDir:           baseDir,
+				baseFilename:      metricsLog,
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       time.Date(2023, 12, 15, 10, 0, 0, 0, time.Local).Unix(),
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				time: uint64(time.Date(2023, 12, 15, 10, 1, 1, 0, time.Local).UnixMilli()),
+				before: func() {
+					_ = os.RemoveAll(baseDir)
+					_ = os.MkdirAll(baseDir, os.FileMode(perm))
+				},
+				file: func() {
+					yesterday := time.Now().Add(-24 * time.Hour).UnixMilli()
+					dateStr := util.FormatDate(uint64(yesterday))
+					todayDateStr := util.FormatDate(uint64(time.Now().UnixMilli()))
+					_, _ = os.Create(baseDir + metricsLog)
+					_, _ = os.Create(baseDir + metricsLog + "." + todayDateStr + ".1")
+					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
+				},
+				clear: func() {
+					_ = os.RemoveAll(baseDir)
+				},
+			},
+			want:    baseDir + metricsLog,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DefaultMetricLogWriter{
+				baseDir:           tt.fields.baseDir,
+				baseFilename:      tt.fields.baseFilename,
+				maxSingleSize:     tt.fields.maxSingleSize,
+				maxFileAmount:     tt.fields.maxFileAmount,
+				timezoneOffsetSec: tt.fields.timezoneOffsetSec,
+				latestOpSec:       tt.fields.latestOpSec,
+				curMetricFile:     tt.fields.curMetricFile,
+				curMetricIdxFile:  tt.fields.curMetricIdxFile,
+				metricOut:         tt.fields.metricOut,
+				idxOut:            tt.fields.idxOut,
+				mux:               tt.fields.mux,
+			}
+			if tt.args.before != nil {
+				tt.args.before()
+			}
+			if tt.args.file != nil {
+				tt.args.file()
+			}
+			newFileName, err := d.rotateWithDateAndNewFileName(tt.args.time)
+			if !tt.wantErr(t, err, fmt.Sprintf("rotateWithDateAndNewFileName(%v)", tt.args.time)) {
+				return
+			}
+			_, _ = os.Create(newFileName)
+			if tt.args.clear != nil {
+				tt.args.clear()
+			}
+			assert.Equalf(t, tt.want, newFileName, "rotateWithDateAndNewFileName(%v)", tt.args.time)
+		})
+	}
+}
+
+func TestDefaultMetricLogWriter_isNewDay(t *testing.T) {
+	_, offset := util.Now().Zone()
+	fmt.Println("offset:", offset)
+	type fields struct {
+		baseDir           string
+		baseFilename      string
+		maxSingleSize     uint64
+		maxFileAmount     uint32
+		timezoneOffsetSec int64
+		latestOpSec       int64
+		curMetricFile     *os.File
+		curMetricIdxFile  *os.File
+		metricOut         *bufio.Writer
+		idxOut            *bufio.Writer
+		mux               *sync.RWMutex
+	}
+	type args struct {
+		lastSec int64
+		sec     int64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "isNewDay true",
+			fields: fields{
+				baseDir:           "/tmp/logs/",
+				baseFilename:      "test-metrics.log",
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       0,
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+
+			args: args{
+				lastSec: time.Date(2023, 12, 14, 23, 59, 59, 0, time.Local).Unix(),
+				sec:     time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).Unix(),
+			},
+			want: true,
+		},
+		{
+			name: "isNewDay false",
+			fields: fields{
+				baseDir:           "/tmp/logs/",
+				baseFilename:      "test-metrics.log",
+				maxSingleSize:     1024,
+				maxFileAmount:     10,
+				timezoneOffsetSec: int64(offset),
+				latestOpSec:       0,
+				curMetricFile:     nil,
+				curMetricIdxFile:  nil,
+				metricOut:         nil,
+				idxOut:            nil,
+				mux:               nil,
+			},
+			args: args{
+				lastSec: time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).Unix(),
+				sec:     time.Date(2023, 12, 15, 23, 59, 59, 0, time.Local).Unix(),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DefaultMetricLogWriter{
+				baseDir:           tt.fields.baseDir,
+				baseFilename:      tt.fields.baseFilename,
+				maxSingleSize:     tt.fields.maxSingleSize,
+				maxFileAmount:     tt.fields.maxFileAmount,
+				timezoneOffsetSec: tt.fields.timezoneOffsetSec,
+				latestOpSec:       tt.fields.latestOpSec,
+				curMetricFile:     tt.fields.curMetricFile,
+				curMetricIdxFile:  tt.fields.curMetricIdxFile,
+				metricOut:         tt.fields.metricOut,
+				idxOut:            tt.fields.idxOut,
+				mux:               tt.fields.mux,
+			}
+			assert.Equalf(t, tt.want, d.isNewDay(tt.args.lastSec, tt.args.sec), "isNewDay(%v, %v)", tt.args.lastSec, tt.args.sec)
+		})
+	}
+}

--- a/core/log/metric/writer_test.go
+++ b/core/log/metric/writer_test.go
@@ -160,7 +160,7 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
 				},
 				file: func() {
-					yesterday := time.Now().Add(-24 * time.Hour).Unix() * 1000
+					yesterday := time.Now().Add(-24*time.Hour).Unix() * 1000
 					dateStr := util.FormatDate(uint64(yesterday))
 					_, _ = os.Create(baseDir + metricsLog)
 					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
@@ -194,7 +194,7 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
 				},
 				file: func() {
-					yesterday := time.Now().Add(-24 * time.Hour).Unix() * 1000
+					yesterday := time.Now().Add(-24*time.Hour).Unix() * 1000
 					dateStr := util.FormatDate(uint64(yesterday))
 					todayDateStr := util.FormatDate(uint64(time.Now().Unix() * 1000))
 					_, _ = os.Create(baseDir + metricsLog)

--- a/core/log/metric/writer_test.go
+++ b/core/log/metric/writer_test.go
@@ -61,7 +61,7 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 				mux:               nil,
 			},
 			args: args{
-				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).UnixMilli()),
+				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).Unix() * 1000),
 				before: func() {
 					_ = os.RemoveAll(baseDir)
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
@@ -89,7 +89,7 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 				mux:               nil,
 			},
 			args: args{
-				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).UnixMilli()),
+				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).Unix() * 1000),
 				before: func() {
 					_ = os.RemoveAll(baseDir)
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
@@ -120,13 +120,13 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 				mux:               nil,
 			},
 			args: args{
-				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).UnixMilli()),
+				time: uint64(time.Date(2023, 12, 15, 0, 0, 0, 0, time.Local).Unix() * 1000),
 				before: func() {
 					_ = os.RemoveAll(baseDir)
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
 				},
 				file: func() {
-					yesterday := time.Date(2023, 12, 14, 23, 59, 59, 0, time.Local).UnixMilli()
+					yesterday := time.Date(2023, 12, 14, 23, 59, 59, 0, time.Local).Unix() * 1000
 					dateStr := util.FormatDate(uint64(yesterday))
 					_, _ = os.Create(baseDir + metricsLog)
 					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
@@ -154,13 +154,13 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 				mux:               nil,
 			},
 			args: args{
-				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).UnixMilli()),
+				time: uint64(time.Date(2023, 12, 15, 10, 0, 1, 0, time.Local).Unix() * 1000),
 				before: func() {
 					_ = os.RemoveAll(baseDir)
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
 				},
 				file: func() {
-					yesterday := time.Now().Add(-24 * time.Hour).UnixMilli()
+					yesterday := time.Now().Add(-24 * time.Hour).Unix() * 1000
 					dateStr := util.FormatDate(uint64(yesterday))
 					_, _ = os.Create(baseDir + metricsLog)
 					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")
@@ -188,15 +188,15 @@ func TestDefaultMetricLogWriter_rotateWithDateAndNewFileName(t *testing.T) {
 				mux:               nil,
 			},
 			args: args{
-				time: uint64(time.Date(2023, 12, 15, 10, 1, 1, 0, time.Local).UnixMilli()),
+				time: uint64(time.Date(2023, 12, 15, 10, 1, 1, 0, time.Local).Unix() * 1000),
 				before: func() {
 					_ = os.RemoveAll(baseDir)
 					_ = os.MkdirAll(baseDir, os.FileMode(perm))
 				},
 				file: func() {
-					yesterday := time.Now().Add(-24 * time.Hour).UnixMilli()
+					yesterday := time.Now().Add(-24 * time.Hour).Unix() * 1000
 					dateStr := util.FormatDate(uint64(yesterday))
-					todayDateStr := util.FormatDate(uint64(time.Now().UnixMilli()))
+					todayDateStr := util.FormatDate(uint64(time.Now().Unix() * 1000))
 					_, _ = os.Create(baseDir + metricsLog)
 					_, _ = os.Create(baseDir + metricsLog + "." + todayDateStr + ".1")
 					_, _ = os.Create(baseDir + metricsLog + "." + dateStr + ".1")

--- a/util/file.go
+++ b/util/file.go
@@ -47,3 +47,11 @@ func CreateDirIfNotExists(dirname string) error {
 	}
 	return nil
 }
+
+func FileRename(oldName, newName string) bool {
+	err := os.Rename(oldName, newName)
+	if err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

impove sentinel latest metric log file name to xxx-metrics.log. 

Fix the latest file name format for convenient log collection.

### Does this pull request fix one issue?

NONE

### Describe how you did it

1. replace func `nextFileNameOfTime`  with func `rotateWithDateAndNewFileName` 
2. init `latestOpSec` before roll log file when app starting

### Describe how to verify it

The implementation can be verified via go test.

### Special notes for reviews