### PR TITLE
chore: remove unnecessary time convert

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	TimeFormat         = "2006-01-02 15:04:05"
-	DateFormat         = "2006-01-02"
-	UnixTimeUnitOffset = uint64(time.Millisecond / time.Nanosecond)
+	TimeFormat = "2006-01-02 15:04:05"
+	DateFormat = "2006-01-02"
 )
 
 var (
@@ -84,7 +83,7 @@ func (t *RealClock) CurrentTimeMillis() uint64 {
 	if tickerNow > uint64(0) {
 		return tickerNow
 	}
-	return uint64(time.Now().UnixNano()) / UnixTimeUnitOffset
+	return uint64(time.Now().UnixMilli())
 }
 
 func (t *RealClock) CurrentTimeNano() uint64 {
@@ -120,7 +119,7 @@ func (t *MockClock) Sleep(d time.Duration) {
 }
 
 func (t *MockClock) CurrentTimeMillis() uint64 {
-	return uint64(t.Now().UnixNano()) / UnixTimeUnitOffset
+	return uint64(t.Now().UnixMilli())
 }
 
 func (t *MockClock) CurrentTimeNano() uint64 {
@@ -272,12 +271,12 @@ func NewTicker(d time.Duration) Ticker {
 
 // FormatTimeMillis formats Unix timestamp (ms) to time string.
 func FormatTimeMillis(tsMillis uint64) string {
-	return time.Unix(0, int64(tsMillis*UnixTimeUnitOffset)).Format(TimeFormat)
+	return time.Unix(0, int64(tsMillis)*int64(time.Millisecond)).Format(TimeFormat)
 }
 
 // FormatDate formats Unix timestamp (ms) to date string
 func FormatDate(tsMillis uint64) string {
-	return time.Unix(0, int64(tsMillis*UnixTimeUnitOffset)).Format(DateFormat)
+	return time.Unix(0, int64(tsMillis)*int64(time.Millisecond)).Format(DateFormat)
 }
 
 // Returns the current Unix timestamp in milliseconds.

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -184,7 +184,7 @@ func BenchmarkCurrentTimeInMs(b *testing.B) {
 		if tickerNow > uint64(0) {
 			return tickerNow
 		}
-		return uint64(time.Now().UnixNano()) / UnixTimeUnitOffset
+		return uint64(time.Now().UnixMilli())
 	}
 
 	b.ReportAllocs()

--- a/util/time_ticker.go
+++ b/util/time_ticker.go
@@ -24,10 +24,10 @@ var nowInMs = uint64(0)
 // StartTimeTicker starts a background task that caches current timestamp per millisecond,
 // which may provide better performance in high-concurrency scenarios.
 func StartTimeTicker() {
-	atomic.StoreUint64(&nowInMs, uint64(time.Now().UnixNano())/UnixTimeUnitOffset)
+	atomic.StoreUint64(&nowInMs, uint64(time.Now().UnixMilli()))
 	go func() {
 		for {
-			now := uint64(time.Now().UnixNano()) / UnixTimeUnitOffset
+			now := uint64(time.Now().UnixMilli())
 			atomic.StoreUint64(&nowInMs, now)
 			time.Sleep(time.Millisecond)
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it
remove unnecessary time convert


### Does this pull request fix one issue?
None

### Describe how you did it
To  get current time in milliseconds, just call time.Now().UnixMilli() directly instead of time.Now().UnixNano() / (time.Millisecond / time.Nanosecond). 

### Describe how to verify it
Clearly

### Special notes for reviews