### PR TITLE
[feature] support regex in flow control and isolation for resource name

### DIFF
--- a/core/flow/rule.go
+++ b/core/flow/rule.go
@@ -117,6 +117,8 @@ type Rule struct {
 	HighMemUsageThreshold int64 `json:"highMemUsageThreshold"`
 	MemLowWaterMarkBytes  int64 `json:"memLowWaterMarkBytes"`
 	MemHighWaterMarkBytes int64 `json:"memHighWaterMarkBytes"`
+	// Regex indicates whether the rule is a regex rule
+	Regex bool `json:"regex"`
 }
 
 func (r *Rule) isEqualsTo(newRule *Rule) bool {

--- a/core/flow/rule_manager_test.go
+++ b/core/flow/rule_manager_test.go
@@ -263,7 +263,7 @@ func Test_buildResourceTrafficShapingController(t *testing.T) {
 			MaxQueueingTimeMs:      10,
 		}
 		assert.True(t, len(tcMap["abc1"]) == 0)
-		tcs := buildResourceTrafficShapingController("abc1", []*Rule{r1, r2}, tcMap["abc1"])
+		tcs, _ := buildResourceTrafficShapingController("abc1", []*Rule{r1, r2}, tcMap["abc1"])
 		assert.True(t, len(tcs) == 2)
 		assert.True(t, tcs[0].BoundRule() == r1)
 		assert.True(t, tcs[1].BoundRule() == r2)
@@ -415,7 +415,7 @@ func Test_buildResourceTrafficShapingController(t *testing.T) {
 			StatIntervalInMs:       50000,
 		}
 
-		tcs := buildResourceTrafficShapingController("abc1", []*Rule{r12, r22, r32, r42}, tcMap["abc1"])
+		tcs, _ := buildResourceTrafficShapingController("abc1", []*Rule{r12, r22, r32, r42}, tcMap["abc1"])
 		assert.True(t, len(tcs) == 4)
 
 		assert.True(t, tcs[0].BoundRule() == r12)

--- a/core/isolation/rule.go
+++ b/core/isolation/rule.go
@@ -46,13 +46,16 @@ type Rule struct {
 	// Currently Concurrency is supported for concurrency limiting.
 	MetricType MetricType `json:"metricType"`
 	Threshold  uint32     `json:"threshold"`
+	// Regex indicates whether the rule is a regex rule
+	Regex bool `json:"regex"`
 }
 
 func (r *Rule) String() string {
 	b, err := json.Marshal(r)
 	if err != nil {
 		// Return the fallback string
-		return fmt.Sprintf("{Id=%s, Resource=%s, MetricType=%s, Threshold=%d}", r.ID, r.Resource, r.MetricType.String(), r.Threshold)
+		return fmt.Sprintf("{Id=%s, Resource=%s, MetricType=%s, Threshold=%d, Regex=%v}", r.ID, r.Resource,
+			r.MetricType.String(), r.Threshold, r.Regex)
 	}
 	return string(b)
 }

--- a/core/isolation/slot_test.go
+++ b/core/isolation/slot_test.go
@@ -1,0 +1,155 @@
+package isolation
+
+import (
+	"testing"
+
+	"github.com/alibaba/sentinel-golang/core/base"
+	"github.com/alibaba/sentinel-golang/core/stat"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Isolation_Pass(t *testing.T) {
+	slot := &Slot{}
+	statSlot := stat.Slot{}
+	res := base.NewResourceWrapper("abc", base.ResTypeCommon, base.Inbound)
+	resNode := stat.GetOrCreateResourceNode("abc", base.ResTypeCommon)
+	ctx := &base.EntryContext{
+		Resource: res,
+		StatNode: resNode,
+		Input: &base.SentinelInput{
+			BatchCount: 1,
+		},
+		RuleCheckResult: nil,
+		Data:            nil,
+	}
+
+	ret := slot.Check(ctx)
+	if ret != nil {
+		t.Fail()
+		return
+	}
+
+	r := &Rule{
+		Resource:   "abc",
+		MetricType: Concurrency,
+		Threshold:  10,
+	}
+	_, e := LoadRules([]*Rule{r})
+	if e != nil {
+		t.Fail()
+		return
+	}
+	for i := 0; i < 10; i++ {
+		ret = slot.Check(ctx)
+		if ret != nil {
+			t.Fail()
+			return
+		}
+		statSlot.OnEntryPassed(ctx)
+	}
+
+	ret = slot.Check(ctx)
+	assert.NotNil(t, ret)
+}
+
+func Test_RegexIsolation_Pass(t *testing.T) {
+	slot := &Slot{}
+	statSlot1 := stat.Slot{}
+	statSlot2 := stat.Slot{}
+	res1 := base.NewResourceWrapper("abc/123", base.ResTypeCommon, base.Inbound)
+	res2 := base.NewResourceWrapper("abc/456", base.ResTypeCommon, base.Inbound)
+	resNode1 := stat.GetOrCreateResourceNode("abc/123", base.ResTypeCommon)
+	resNode2 := stat.GetOrCreateResourceNode("abc/456", base.ResTypeCommon)
+	ctx1 := &base.EntryContext{
+		Resource: res1,
+		StatNode: resNode1,
+		Input: &base.SentinelInput{
+			BatchCount: 1,
+		},
+		RuleCheckResult: nil,
+		Data:            nil,
+	}
+	ctx2 := &base.EntryContext{
+		Resource: res2,
+		StatNode: resNode2,
+		Input: &base.SentinelInput{
+			BatchCount: 1,
+		},
+		RuleCheckResult: nil,
+		Data:            nil,
+	}
+
+	ret1 := slot.Check(ctx1)
+	if ret1 != nil {
+		t.Fail()
+		return
+	}
+	ret2 := slot.Check(ctx2)
+	if ret2 != nil {
+		t.Fail()
+		return
+	}
+
+	r := &Rule{
+		Resource:   "abc/\\d+",
+		MetricType: Concurrency,
+		Threshold:  10,
+		Regex:      true,
+	}
+	_, e := LoadRules([]*Rule{r})
+	if e != nil {
+		t.Fail()
+		return
+	}
+
+	n := 10
+	for i := 0; i < n; i++ {
+		ret := slot.Check(ctx1)
+		if ret != nil {
+			t.Fail()
+			return
+		}
+
+		statSlot1.OnEntryPassed(ctx1)
+	}
+
+	ret1 = slot.Check(ctx1)
+	assert.NotNil(t, ret1)
+
+	for i := 0; i < n; i++ {
+		statSlot1.OnCompleted(ctx1)
+	}
+
+	for i := 0; i < n; i++ {
+		ret := slot.Check(ctx1)
+		if ret != nil {
+			t.Fail()
+			return
+		}
+		statSlot1.OnEntryPassed(ctx1)
+	}
+
+	for i := 0; i < n; i++ {
+		ret := slot.Check(ctx2)
+		if ret != nil {
+			t.Fail()
+			return
+		}
+		statSlot2.OnEntryPassed(ctx2)
+	}
+	ret2 = slot.Check(ctx2)
+	assert.NotNil(t, ret2)
+
+	for i := 0; i < n; i++ {
+		statSlot2.OnCompleted(ctx2)
+	}
+
+	for i := 0; i < n; i++ {
+		ret := slot.Check(ctx2)
+		if ret != nil {
+			t.Fail()
+			return
+		}
+		statSlot2.OnEntryPassed(ctx2)
+	}
+}

--- a/ext/datasource/helper_test.go
+++ b/ext/datasource/helper_test.go
@@ -532,10 +532,10 @@ func TestIsolationRuleJsonArrayParser(t *testing.T) {
 		rules := properties.([]*isolation.Rule)
 		assert.True(t, err == nil)
 		assert.True(t, len(rules) == 4)
-		assert.True(t, strings.Contains(rules[0].String(), `{"resource":"abc","metricType":0,"threshold":100}`))
-		assert.True(t, strings.Contains(rules[1].String(), `{"resource":"abc","metricType":0,"threshold":90}`))
-		assert.True(t, strings.Contains(rules[2].String(), `{"resource":"abc","metricType":0,"threshold":80}`))
-		assert.True(t, strings.Contains(rules[3].String(), `{"resource":"abc","metricType":0,"threshold":70}`))
+		assert.True(t, strings.Contains(rules[0].String(), `{"resource":"abc","metricType":0,"threshold":100,"regex":false}`))
+		assert.True(t, strings.Contains(rules[1].String(), `{"resource":"abc","metricType":0,"threshold":90,"regex":false}`))
+		assert.True(t, strings.Contains(rules[2].String(), `{"resource":"abc","metricType":0,"threshold":80,"regex":false}`))
+		assert.True(t, strings.Contains(rules[3].String(), `{"resource":"abc","metricType":0,"threshold":70,"regex":false}`))
 	})
 
 	t.Run("TestIsolationRuleJsonArrayParser_Nil", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

By allowing resource names to be defined using regex patterns, users can apply unified rules to groups of resources that match specific naming conventions or dynamic patterns (e.g., RESTful API endpoints with variable path parameters). This enhancement reduces the need for repetitive rule definitions and improves adaptability to evolving service structures

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

1. Added a Regex boolean flag to FlowRule and IsolationRule to mark whether the Resource uses a regular expression.
2. Rules with regex patterns are stored in a dedicated regexRulesMap to separate them from static resource rules.
3. Find regex-based rules using pattern matching when getRulesOfResource.
4. Improved performance by caching compiled regex patterns to prevent redundant compilations during repeated evaluations.

### Describe how to verify it

1. Define a flow or isolation rule with Resource set to a regex pattern (e.g., abc/*) and Regex enabled.
5. Trigger requests with resource names like abc/123, abc/456.
6. Validate that the rule is correctly applied based on the configured threshold and strategy.

### Special notes for reviews