### PR TITLE
feat: Compatible with higher versions of agollo and supports fetching  rules from specified namespace.

### DIFF
--- a/pkg/datasource/apollo/apollo.go
+++ b/pkg/datasource/apollo/apollo.go
@@ -5,20 +5,24 @@ import (
 	"github.com/apolloconfig/agollo/v4"
 	"github.com/apolloconfig/agollo/v4/component/log"
 	"github.com/apolloconfig/agollo/v4/env/config"
+	"github.com/apolloconfig/agollo/v4/storage"
 	"github.com/pkg/errors"
 )
 
 var (
 	ErrEmptyKey   = errors.New("property key is empty")
 	ErrMissConfig = errors.New("miss config")
+	ErrConfigNil  = errors.New("cant find a config by the special namespace")
 )
+
+const defaultNamespace = "application"
 
 type Option func(o *options)
 
 type options struct {
-	handlers []datasource.PropertyHandler
-	logger   log.LoggerInterface
-	client   *agollo.Client
+	handlers  []datasource.PropertyHandler
+	logger    log.LoggerInterface
+	namespace string
 }
 
 // WithPropertyHandlers set property handlers
@@ -35,11 +39,25 @@ func WithLogger(logger log.LoggerInterface) Option {
 	}
 }
 
+// WithNamespace set apollo namespace to supports fetching rules from specified namespace.
+func WithNamespace(namespace string) Option {
+	return func(o *options) {
+		o.namespace = namespace
+	}
+}
+
 // apolloDatasource implements datasource.Datasource
 type apolloDatasource struct {
 	datasource.Base
-	client      *agollo.Client
+	client      apolloClient
 	propertyKey string
+	namespace   string
+}
+
+// apolloClient a simple apollo client to support sentinel datasource
+type apolloClient interface {
+	GetConfig(namespace string) *storage.Config
+	AddChangeListener(listener storage.ChangeListener)
 }
 
 // NewDatasource create apollo datasource
@@ -56,6 +74,9 @@ func NewDatasource(conf *config.AppConfig, propertyKey string, opts ...Option) (
 	for _, opt := range opts {
 		opt(option)
 	}
+	if option.namespace == "" {
+		option.namespace = defaultNamespace
+	}
 	agollo.SetLogger(option.logger)
 	apolloClient, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
 		return conf, nil
@@ -66,6 +87,7 @@ func NewDatasource(conf *config.AppConfig, propertyKey string, opts ...Option) (
 	ds := &apolloDatasource{
 		client:      apolloClient,
 		propertyKey: propertyKey,
+		namespace:   option.namespace,
 	}
 	for _, handler := range option.handlers {
 		ds.AddPropertyHandler(handler)
@@ -74,7 +96,11 @@ func NewDatasource(conf *config.AppConfig, propertyKey string, opts ...Option) (
 }
 
 func (a *apolloDatasource) ReadSource() ([]byte, error) {
-	value := a.client.GetValue(a.propertyKey)
+	cfg := a.client.GetConfig(a.namespace)
+	if cfg == nil {
+		return nil, ErrConfigNil
+	}
+	value := cfg.GetValue(a.propertyKey)
 	return []byte(value), nil
 }
 

--- a/pkg/datasource/apollo/listener.go
+++ b/pkg/datasource/apollo/listener.go
@@ -10,7 +10,7 @@ type customChangeListener struct {
 
 func (c *customChangeListener) OnChange(event *storage.ChangeEvent) {
 	for key, value := range event.Changes {
-		if c.ds.propertyKey == key {
+		if c.ds.namespace == event.Namespace && c.ds.propertyKey == key {
 			c.ds.handle([]byte(value.NewValue.(string)))
 		}
 	}
@@ -18,7 +18,7 @@ func (c *customChangeListener) OnChange(event *storage.ChangeEvent) {
 
 func (c *customChangeListener) OnNewestChange(event *storage.FullChangeEvent) {
 	for key, value := range event.Changes {
-		if c.ds.propertyKey == key {
+		if c.ds.namespace == event.Namespace && c.ds.propertyKey == key {
 			c.ds.handle([]byte(value.(string)))
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
1. Create a new specialized `apolloClient` interface to replace `*agollo.Client`, enabling apolloDataSource to be compatible with all current versions of agollo.
2. add `WithNamespace` option to support fetching  rules from specified namespace.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #600

### Describe how you did it


### Describe how to verify it


### Special notes for reviews