### PR TITLE
fix: 修复热点参数并发度限流的 TOCTOU 竞态条件 (#599)

### DIFF
--- a/core/hotspot/concurrency_stat_slot.go
+++ b/core/hotspot/concurrency_stat_slot.go
@@ -38,6 +38,20 @@ func (s *ConcurrencyStatSlot) Order() uint32 {
 }
 
 func (c *ConcurrencyStatSlot) OnEntryPassed(ctx *base.EntryContext) {
+	// The concurrency counter is already incremented atomically in the Check phase
+	// (performCheckingForConcurrencyMetric), so no increment is needed here.
+}
+
+func (c *ConcurrencyStatSlot) OnEntryBlocked(ctx *base.EntryContext, blockError *base.BlockError) {
+	// If hotspot concurrency counters were incremented in the Check phase but the
+	// entry was blocked by a later check slot (e.g., CircuitBreaker), we need to
+	// rollback those increments.
+	if ctx.Data == nil {
+		return
+	}
+	if _, ok := ctx.Data[hotspotConcurrencyPassedKey]; !ok {
+		return
+	}
 	res := ctx.Resource.Name()
 	tcs := getTrafficControllersFor(res)
 	for _, tc := range tcs {
@@ -51,17 +65,10 @@ func (c *ConcurrencyStatSlot) OnEntryPassed(ctx *base.EntryContext) {
 		metric := tc.BoundMetric()
 		concurrencyPtr, existed := metric.ConcurrencyCounter.Get(arg)
 		if !existed || concurrencyPtr == nil {
-			if logging.DebugEnabled() {
-				logging.Debug("[ConcurrencyStatSlot OnEntryPassed] Parameter does not exist in ConcurrencyCounter.", "argument", arg)
-			}
 			continue
 		}
-		atomic.AddInt64(concurrencyPtr, 1)
+		atomic.AddInt64(concurrencyPtr, -1)
 	}
-}
-
-func (c *ConcurrencyStatSlot) OnEntryBlocked(ctx *base.EntryContext, blockError *base.BlockError) {
-	// Do nothing
 }
 
 func (c *ConcurrencyStatSlot) OnCompleted(ctx *base.EntryContext) {

--- a/core/hotspot/slot.go
+++ b/core/hotspot/slot.go
@@ -15,6 +15,8 @@
 package hotspot
 
 import (
+	"sync/atomic"
+
 	"github.com/alibaba/sentinel-golang/core/base"
 	"github.com/alibaba/sentinel-golang/util"
 )
@@ -22,6 +24,10 @@ import (
 const (
 	RuleCheckSlotOrder = 4000
 )
+
+// hotspotConcurrencyPassedKey is the key used in EntryContext.Data to indicate
+// that hotspot concurrency counters have been incremented in the Check phase.
+const hotspotConcurrencyPassedKey = "sentinel_hotspot_concurrency_passed"
 
 var (
 	DefaultSlot = &Slot{}
@@ -40,6 +46,15 @@ func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 
 	result := ctx.RuleCheckResult
 	tcs := getTrafficControllersFor(res)
+
+	// Track concurrency controllers that passed (and incremented their counters)
+	// so we can rollback if a later controller in the same slot blocks.
+	type passedEntry struct {
+		tc  TrafficShapingController
+		arg interface{}
+	}
+	var passedConcurrency []passedEntry
+
 	for _, tc := range tcs {
 		arg := tc.ExtractArgs(ctx)
 		if arg == nil {
@@ -47,9 +62,20 @@ func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 		}
 		r := canPassCheck(tc, arg, batch)
 		if r == nil {
+			if tc.BoundRule().MetricType == Concurrency {
+				passedConcurrency = append(passedConcurrency, passedEntry{tc, arg})
+			}
 			continue
 		}
 		if r.Status() == base.ResultStatusBlocked {
+			// Rollback concurrency counters incremented by earlier controllers in this slot.
+			for _, p := range passedConcurrency {
+				metric := p.tc.BoundMetric()
+				concurrencyPtr, existed := metric.ConcurrencyCounter.Get(p.arg)
+				if existed && concurrencyPtr != nil {
+					atomic.AddInt64(concurrencyPtr, -1)
+				}
+			}
 			return r
 		}
 		if r.Status() == base.ResultStatusShouldWait {
@@ -60,6 +86,16 @@ func (s *Slot) Check(ctx *base.EntryContext) *base.TokenResult {
 			continue
 		}
 	}
+
+	// Mark in context that hotspot concurrency counters have been incremented,
+	// so OnEntryBlocked can rollback if a later check slot blocks.
+	if len(passedConcurrency) > 0 {
+		if ctx.Data == nil {
+			ctx.Data = make(map[interface{}]interface{})
+		}
+		ctx.Data[hotspotConcurrencyPassedKey] = true
+	}
+
 	return result
 }
 

--- a/core/hotspot/traffic_shaping.go
+++ b/core/hotspot/traffic_shaping.go
@@ -118,15 +118,18 @@ func (c *baseTrafficShapingController) performCheckingForConcurrencyMetric(arg i
 	initConcurrency := int64(0)
 	concurrencyPtr := c.metric.ConcurrencyCounter.AddIfAbsent(arg, &initConcurrency)
 	if concurrencyPtr == nil {
-		// First to access this arg
-		return nil
+		// First to access this arg, use the pointer we just stored.
+		concurrencyPtr = &initConcurrency
 	}
-	concurrency := atomic.LoadInt64(concurrencyPtr)
-	concurrency++
+	// Atomically increment the counter first, then check the threshold.
+	// This eliminates the TOCTOU race between check and increment.
+	concurrency := atomic.AddInt64(concurrencyPtr, 1)
 	if specificConcurrency, existed := specificItem[arg]; existed {
 		if concurrency <= specificConcurrency {
 			return nil
 		}
+		// Exceeded threshold, rollback the increment.
+		atomic.AddInt64(concurrencyPtr, -1)
 		msg := fmt.Sprintf("hotspot specific concurrency check blocked, arg: %v", arg)
 		return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow, msg, c.BoundRule(), concurrency)
 	}
@@ -134,6 +137,8 @@ func (c *baseTrafficShapingController) performCheckingForConcurrencyMetric(arg i
 	if concurrency <= threshold {
 		return nil
 	}
+	// Exceeded threshold, rollback the increment.
+	atomic.AddInt64(concurrencyPtr, -1)
 	msg := fmt.Sprintf("hotspot concurrency check blocked, arg: %v", arg)
 	return base.NewTokenResultBlockedWithCause(base.BlockTypeHotSpotParamFlow, msg, c.BoundRule(), concurrency)
 }


### PR DESCRIPTION
### 概述

- 修复热点参数并发度限流中的 TOCTOU（Time-of-Check to Time-of-Use）竞态条件，该问题导致实际并发数超过配置的阈值
- 将 `performCheckingForConcurrencyMetric` 中非原子的"读取-检查-递增"模式替换为原子的"递增-检查-回退"模式
- 处理当请求被后续 Check Slot（如 CircuitBreaker）阻断时，对已递增的并发度计数器的回退

Closes #599

### 问题描述

使用热点参数并发度限流时，当存在多个参数值时，实际并发数会超过配置的阈值。例如配置 `Threshold=2`，两个参数值（`true` 和 `false`），预期资源级最大并发数为 3（`true` 最多 2 + `false` 最多 1），但实际会达到 4。

**根因**：并发度的检查与递增不是原子操作。`performCheckingForConcurrencyMetric` 中的执行流程：

1. 通过 `atomic.LoadInt64` **读取**当前计数器值
2. 在本地变量上 **递增**（`concurrency++`）
3. **检查**阈值（`concurrency <= threshold`）

而**真正的计数器递增**发生在很后面的 `ConcurrencyStatSlot.OnEntryPassed` 回调中（通过 `atomic.AddInt64`）。

在步骤 1（读取）和实际递增之间，多个 goroutine 可以读到相同的旧值，全部通过阈值检查：

```
G1: LoadInt64(ptr) = 1, 本地++ = 2, 2 <= 2 -> 通过
G2: LoadInt64(ptr) = 1, 本地++ = 2, 2 <= 2 -> 通过（G1 还没递增计数器！）
// 之后在 OnEntryPassed 中：
G1: AddInt64(ptr, 1) -> counter = 2
G2: AddInt64(ptr, 1) -> counter = 3  <- 超过阈值！
```

此外，首次访问的情况（`AddIfAbsent` 返回 nil）会完全跳过阈值检查。

### 解决方案

**1. `core/hotspot/traffic_shaping.go` — `performCheckingForConcurrencyMetric`**

将非原子的"读取-递增-检查"模式替换为原子的"递增-检查"模式：

- 使用 `atomic.AddInt64(concurrencyPtr, 1)` 在检查阈值**之前**原子递增计数器
- 若超过阈值，立即通过 `atomic.AddInt64(concurrencyPtr, -1)` 回退
- 修复首次访问的问题：当 `AddIfAbsent` 返回 nil 时，使用已存入缓存的指针（`&initConcurrency`）执行同样的原子检查，而非直接放行

**2. `core/hotspot/slot.go` — `Slot.Check`**

在检查循环中追踪哪些并发度 controller 的计数器已被递增。若后续 controller 阻断请求，回退所有已递增的计数器。同时在 `EntryContext.Data` 中存入标记，供 `OnEntryBlocked` 使用。

**3. `core/hotspot/concurrency_stat_slot.go` — `ConcurrencyStatSlot`**

- `OnEntryPassed`：移除计数器递增（已在 Check 阶段原子完成）
- `OnEntryBlocked`：新增回退逻辑。若请求被**其他** Check Slot 阻断（如 CircuitBreaker order=5000 > HotSpot order=4000），此时热点并发度计数器已被递增，需要回退。通过 `EntryContext.Data` 中的标记判断是否需要回退。
- `OnCompleted`：保持不变（请求结束时递减计数器）

**4. `core/hotspot/concurrency_fix_verify_test.go` — 新增回归测试**

新增 `TestConcurrencyCheckAtomicity_Issue599` 回归测试，直接验证 `performCheckingForConcurrencyMetric` 的原子性：

- **SingleParam**：50 个 goroutine 同时竞争同一参数，验证每批通过检查的数量不超过阈值
- **MultiParam**：50 个 goroutine 分别竞争两个不同参数（paramA 30 个、paramB 20 个），验证每个参数的通过数均不超过阈值
- 每个场景执行 1000 次迭代，带 `-race` 竞态检测

测试结果（修复后）：
```
=== RUN   TestConcurrencyCheckAtomicity_Issue599/SingleParam
    SingleParam: max goroutines passing check in one batch: 2 (threshold=2)
=== RUN   TestConcurrencyCheckAtomicity_Issue599/MultiParam
    MultiParam: threshold exceeded 0/1000 iterations
--- PASS: TestConcurrencyCheckAtomicity_Issue599
```

> **注意**：通过 `api.Entry()` 进行的端到端集成测试仍然会观察到资源级并发度超标。这是因为框架的 `EntryOptions` 对象池复用了 `args` 切片的底层数组（`api/api.go` 中 `o.args = o.args[:0]`），导致 `OnCompleted` 时 `ExtractArgs` 可能读到被后续 Entry 覆写的参数值，从而递减了错误参数的计数器。这是一个独立的预有问题，不在本次修复范围内。

### 测试计划

- [x] 所有 `core/hotspot` 现有测试通过（含 `-race` 竞态检测）
- [x] 所有 `core/...` 包测试通过
- [x] 所有 `api/...` 和 `tests/...` 集成测试通过
- [x] 回归测试验证：50 goroutine x 1000 次迭代，单参数和多参数场景下并发通过数均不超过阈值