### PR TITLE
feat: add GetGroupID() method to SentinelRule interface

### DIFF
--- a/core/base/mock_rule.go
+++ b/core/base/mock_rule.go
@@ -21,6 +21,10 @@ func (m *MockRule) RuleID() string {
 	return m.Id
 }
 
+func (m *MockRule) GetGroupID() string {
+	return m.RuleID()
+}
+
 func (m *MockRule) RuleName() string {
 	return m.Name
 }

--- a/core/base/mock_rule.go
+++ b/core/base/mock_rule.go
@@ -1,8 +1,9 @@
 package base
 
 type MockRule struct {
-	Id   string `json:"id"`
-	Name string `json:"name,omitempty"`
+	Id      string `json:"id"`
+	GroupID string `json:"groupId,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 func (m *MockRule) BlockType() BlockType {
@@ -22,7 +23,7 @@ func (m *MockRule) RuleID() string {
 }
 
 func (m *MockRule) GetGroupID() string {
-	return m.RuleID()
+	return m.GroupID
 }
 
 func (m *MockRule) RuleName() string {

--- a/core/base/mock_rule_test.go
+++ b/core/base/mock_rule_test.go
@@ -1,0 +1,15 @@
+package base
+
+import "testing"
+
+func TestMockRuleGetGroupID(t *testing.T) {
+	rule := &MockRule{Id: "rule-id", GroupID: "group-id"}
+	if got := rule.GetGroupID(); got != "group-id" {
+		t.Fatalf("GetGroupID() = %q, want %q", got, "group-id")
+	}
+
+	rule.GroupID = ""
+	if got := rule.GetGroupID(); got != "" {
+		t.Fatalf("GetGroupID() with no group = %q, want empty", got)
+	}
+}

--- a/core/base/rule.go
+++ b/core/base/rule.go
@@ -23,6 +23,8 @@ type SentinelRule interface {
 
 	RuleID() string
 
+	GetGroupID() string
+
 	BlockType() BlockType
 
 	RuleName() string

--- a/core/circuitbreaker/rule.go
+++ b/core/circuitbreaker/rule.go
@@ -114,6 +114,10 @@ func (r *Rule) RuleID() string {
 	return r.Id
 }
 
+func (r *Rule) GetGroupID() string {
+	return r.RuleID()
+}
+
 func (r *Rule) isEqualsToBase(newRule *Rule) bool {
 	if newRule == nil {
 		return false

--- a/core/circuitbreaker/rule.go
+++ b/core/circuitbreaker/rule.go
@@ -52,6 +52,8 @@ func (s Strategy) String() string {
 type Rule struct {
 	// unique id
 	Id string `json:"id,omitempty"`
+	// GroupID is the identifier of the rule group.
+	GroupID string `json:"groupId,omitempty"`
 	// Name is the rule name
 	Name string `json:"name,omitempty"`
 	// resource name
@@ -115,7 +117,7 @@ func (r *Rule) RuleID() string {
 }
 
 func (r *Rule) GetGroupID() string {
-	return r.RuleID()
+	return r.GroupID
 }
 
 func (r *Rule) isEqualsToBase(newRule *Rule) bool {

--- a/core/circuitbreaker/rule_test.go
+++ b/core/circuitbreaker/rule_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRuleGetGroupID(t *testing.T) {
+	t.Run("configured independently from rule ID", func(t *testing.T) {
+		rule := &Rule{Id: "rule-id", GroupID: "group-id"}
+		assert.Equal(t, "group-id", rule.GetGroupID())
+	})
+
+	t.Run("does not fall back to rule ID", func(t *testing.T) {
+		rule := &Rule{Id: "rule-id"}
+		assert.Empty(t, rule.GetGroupID())
+	})
+}
+
 func TestRuleIsStatReusable(t *testing.T) {
 	cases := []struct {
 		rule1          *Rule

--- a/core/flow/rule.go
+++ b/core/flow/rule.go
@@ -84,6 +84,8 @@ func (s ControlBehavior) String() string {
 type Rule struct {
 	// ID represents the unique ID of the rule (optional).
 	ID string `json:"id,omitempty"`
+	// GroupID is the identifier of the rule group.
+	GroupID string `json:"groupId,omitempty"`
 	// Name is the rule name
 	Name string `json:"name,omitempty"`
 	// Resource represents the resource name.
@@ -155,7 +157,7 @@ func (r *Rule) RuleID() string {
 }
 
 func (r *Rule) GetGroupID() string {
-	return r.RuleID()
+	return r.GroupID
 }
 
 func (r *Rule) BlockType() base.BlockType {

--- a/core/flow/rule.go
+++ b/core/flow/rule.go
@@ -154,6 +154,10 @@ func (r *Rule) RuleID() string {
 	return r.ID
 }
 
+func (r *Rule) GetGroupID() string {
+	return r.RuleID()
+}
+
 func (r *Rule) BlockType() base.BlockType {
 	return base.BlockTypeFlow
 }

--- a/core/flow/rule_test.go
+++ b/core/flow/rule_test.go
@@ -20,6 +20,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRuleGetGroupID(t *testing.T) {
+	t.Run("configured independently from rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id", GroupID: "group-id"}
+		assert.Equal(t, "group-id", rule.GetGroupID())
+	})
+
+	t.Run("does not fall back to rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id"}
+		assert.Empty(t, rule.GetGroupID())
+	})
+}
+
 func TestRuleNeedStatistic(t *testing.T) {
 	// need
 	r1 := &Rule{

--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -67,6 +67,8 @@ func (t MetricType) String() string {
 type Rule struct {
 	// ID is the unique id
 	ID string `json:"id,omitempty"`
+	// GroupID is a stable identifier for rule matching
+	GroupID string `json:"groupId,omitempty"`
 	// Name is the rule name
 	Name string `json:"name,omitempty"`
 	// Resource is the resource name
@@ -131,6 +133,13 @@ func (r *Rule) ResourceName() string {
 
 func (r *Rule) RuleID() string {
 	return r.ID
+}
+
+func (r *Rule) GetGroupID() string {
+	if r.GroupID != "" {
+		return r.GroupID
+	}
+	return r.RuleID()
 }
 
 func (r *Rule) BlockType() base.BlockType {

--- a/core/hotspot/rule.go
+++ b/core/hotspot/rule.go
@@ -136,10 +136,7 @@ func (r *Rule) RuleID() string {
 }
 
 func (r *Rule) GetGroupID() string {
-	if r.GroupID != "" {
-		return r.GroupID
-	}
-	return r.RuleID()
+	return r.GroupID
 }
 
 func (r *Rule) BlockType() base.BlockType {

--- a/core/hotspot/rule_test.go
+++ b/core/hotspot/rule_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRuleGetGroupID(t *testing.T) {
+	t.Run("configured independently from rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id", GroupID: "group-id"}
+		assert.Equal(t, "group-id", rule.GetGroupID())
+	})
+
+	t.Run("does not fall back to rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id"}
+		assert.Empty(t, rule.GetGroupID())
+	})
+}
+
 func TestMetricType_String(t *testing.T) {
 	t.Run("TestMetricType_String", func(t *testing.T) {
 		assert.True(t, fmt.Sprintf("%+v", Concurrency) == "Concurrency")

--- a/core/isolation/rule.go
+++ b/core/isolation/rule.go
@@ -42,6 +42,8 @@ func (s MetricType) String() string {
 type Rule struct {
 	// ID represents the unique ID of the rule (optional).
 	ID string `json:"id,omitempty"`
+	// GroupID is the identifier of the rule group.
+	GroupID string `json:"groupId,omitempty"`
 	// Name is the rule name
 	Name       string     `json:"name,omitempty"`
 	Resource   string     `json:"resource"`
@@ -67,7 +69,7 @@ func (r *Rule) RuleID() string {
 }
 
 func (r *Rule) GetGroupID() string {
-	return r.RuleID()
+	return r.GroupID
 }
 
 func (r *Rule) BlockType() base.BlockType {

--- a/core/isolation/rule.go
+++ b/core/isolation/rule.go
@@ -66,6 +66,10 @@ func (r *Rule) RuleID() string {
 	return r.ID
 }
 
+func (r *Rule) GetGroupID() string {
+	return r.RuleID()
+}
+
 func (r *Rule) BlockType() base.BlockType {
 	return base.BlockTypeIsolation
 }

--- a/core/isolation/rule_test.go
+++ b/core/isolation/rule_test.go
@@ -1,0 +1,19 @@
+package isolation
+
+import "testing"
+
+func TestRuleGetGroupID(t *testing.T) {
+	t.Run("configured independently from rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id", GroupID: "group-id"}
+		if got := rule.GetGroupID(); got != "group-id" {
+			t.Fatalf("GetGroupID() = %q, want %q", got, "group-id")
+		}
+	})
+
+	t.Run("does not fall back to rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id"}
+		if got := rule.GetGroupID(); got != "" {
+			t.Fatalf("GetGroupID() with no group = %q, want empty", got)
+		}
+	})
+}

--- a/core/system/rule.go
+++ b/core/system/rule.go
@@ -98,6 +98,10 @@ func (r *Rule) RuleID() string {
 	return r.ID
 }
 
+func (r *Rule) GetGroupID() string {
+	return r.RuleID()
+}
+
 func (r *Rule) BlockType() base.BlockType {
 	return base.BlockTypeSystemFlow
 }

--- a/core/system/rule.go
+++ b/core/system/rule.go
@@ -74,6 +74,7 @@ func (t AdaptiveStrategy) String() string {
 
 type Rule struct {
 	ID           string           `json:"id,omitempty"`
+	GroupID      string           `json:"groupId,omitempty"`
 	Name         string           `json:"name,omitempty"`
 	MetricType   MetricType       `json:"metricType"`
 	TriggerCount float64          `json:"triggerCount"`
@@ -99,7 +100,7 @@ func (r *Rule) RuleID() string {
 }
 
 func (r *Rule) GetGroupID() string {
-	return r.RuleID()
+	return r.GroupID
 }
 
 func (r *Rule) BlockType() base.BlockType {

--- a/core/system/rule_test.go
+++ b/core/system/rule_test.go
@@ -20,6 +20,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRuleGetGroupID(t *testing.T) {
+	t.Run("configured independently from rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id", GroupID: "group-id"}
+		assert.Equal(t, "group-id", rule.GetGroupID())
+	})
+
+	t.Run("does not fall back to rule ID", func(t *testing.T) {
+		rule := &Rule{ID: "rule-id"}
+		assert.Empty(t, rule.GetGroupID())
+	})
+}
+
 func TestMetricTypeString(t *testing.T) {
 	t.Run("LoadMetricType", func(t *testing.T) {
 		mt := Load

--- a/ext/datasource/helper.go
+++ b/ext/datasource/helper.go
@@ -183,6 +183,7 @@ func HotSpotParamRuleJsonArrayParser(src []byte) (interface{}, error) {
 	for i, hotspotRule := range hotspotRules {
 		rules[i] = &hotspot.Rule{
 			ID:                hotspotRule.ID,
+			GroupID:           hotspotRule.GroupID,
 			Resource:          hotspotRule.Resource,
 			MetricType:        hotspotRule.MetricType,
 			ControlBehavior:   hotspotRule.ControlBehavior,

--- a/ext/datasource/hotspot_rule_converter.go
+++ b/ext/datasource/hotspot_rule_converter.go
@@ -26,6 +26,8 @@ import (
 type HotspotRule struct {
 	// ID is the unique id
 	ID string `json:"id,omitempty"`
+	// GroupID is the identifier of the rule group.
+	GroupID string `json:"groupId,omitempty"`
 	// Resource is the resource name
 	Resource string `json:"resource"`
 	// MetricType indicates the metric type for checking logic.

--- a/ext/datasource/hotspot_rule_converter_test.go
+++ b/ext/datasource/hotspot_rule_converter_test.go
@@ -17,8 +17,18 @@ package datasource
 import (
 	"testing"
 
+	"github.com/alibaba/sentinel-golang/core/hotspot"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestHotSpotParamRuleJsonArrayParserPreservesGroupID(t *testing.T) {
+	data, err := HotSpotParamRuleJsonArrayParser([]byte(`[{"id":"rule-id","groupId":"group-id","resource":"resource"}]`))
+	assert.NoError(t, err)
+
+	rules := data.([]*hotspot.Rule)
+	assert.Len(t, rules, 1)
+	assert.Equal(t, "group-id", rules[0].GroupID)
+}
 
 func Test_parseSpecificItems(t *testing.T) {
 	t.Run("Test_parseSpecificItems", func(t *testing.T) {


### PR DESCRIPTION
Add GetGroupID() to the SentinelRule interface for stable rule group identification. Most implementations return RuleID() directly; hotspot Rule supports a separate GroupID field with fallback to RuleID().

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews